### PR TITLE
Use a text for the certificate chain (fixes #79)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,26 @@
             crossorigin="anonymous"></script>
   </head>
   <body>
+    <textarea id="certificate" rows="18" cols="64">-----BEGIN CERTIFICATE-----
+MIIC0DCCAlUCCQDh7ZXFZjOO+jAKBggqhkjOPQQDAjCB0DELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcxHDAa
+BgNVBAoME01vemlsbGEgQ29ycG9yYXRpb24xNTAzBgNVBAsMLEF1dG9ncmFwaCBm
+b3IgS2ludG8gU2V0dGluZ3MgRGV2IGVudmlyb25tZW50MRYwFAYDVQQDDA1BdXRv
+Z3JhcGggWDVVMScwJQYJKoZIhvcNAQkBFhhzdG9yYWdlLXRlYW1AbW96aWxsYS5j
+b20wHhcNMTYwNDI5MTQ1ODA4WhcNMTcwNDI5MTQ1ODA4WjCB0DELMAkGA1UEBhMC
+VVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcx
+HDAaBgNVBAoME01vemlsbGEgQ29ycG9yYXRpb24xNTAzBgNVBAsMLEF1dG9ncmFw
+aCBmb3IgS2ludG8gU2V0dGluZ3MgRGV2IGVudmlyb25tZW50MRYwFAYDVQQDDA1B
+dXRvZ3JhcGggWDVVMScwJQYJKoZIhvcNAQkBFhhzdG9yYWdlLXRlYW1AbW96aWxs
+YS5jb20wdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAS12UsecmKNRm4+L+jt1++/dENE
+EJIICW7X7q8sbaKKlbZWGkcgHqGWrGrIzK0wgMjtLiRKIwwp7izx+XEgueku7K/o
+bAKrURi/twi8DGCWOU7JV4Os+MV+pLLab2ehGWcwCgYIKoZIzj0EAwIDaQAwZgIx
+AKtsG9nBvvgc81gHZCiVwYgK6qdw1B9eHloKN6aCRfppth/2vLwn4EaB7cmBiI67
+UwIxALKkJz8tMlCloUgFaXuuzcoP16O1EB7l9RNM16hrA7Dz3NWMGCUMxSSYBiFo
+WHFmvQ==
+-----END CERTIFICATE-----</textarea>
+    <br/>
+    <button id="sync">Sync!</button>
     <script type="text/javascript" src="canonicaljson.js"></script>
     <script type="text/javascript" src="x509ecdsa.js"></script>
     <script type="text/javascript" src="webcrypto.js"></script>

--- a/demo/index.js
+++ b/demo/index.js
@@ -5,7 +5,7 @@ function log(message) {
 }
 
 
-function main() {
+function sync() {
   const kinto = new Kinto({
     remote: "https://kinto-reader.dev.mozaws.net/v1",
     bucket: "blocklists"
@@ -27,8 +27,10 @@ function main() {
             return CanonicalJSON.stringify(merged);
           }),
         fetchCollectionMetadata(collection)
-         .then(({x5u, signature}) => {
-           return loadPublicKey(x5u)
+         .then(({signature}) => {
+           log("Import the public key");
+           const certChain = document.getElementById("certificate").value;
+           return loadKey(certChain)
              .then((publicKey) => {return {publicKey, signature}});
          })
       ])
@@ -88,16 +90,8 @@ function main() {
       // Sort list by record id.
       .sort((a, b) => a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
   }
-
-  function loadPublicKey(x5u) {
-    log(`Fetch public key from ${x5u}`);
-    return fetch(x5u)
-      .then((res) => res.text())
-      .then((certChain) => {
-        log("Import the public key");
-        return loadKey(certChain);
-      });
-  }
 }
 
-window.addEventListener("DOMContentLoaded", main);
+window.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("sync").addEventListener("click", sync);
+});


### PR DESCRIPTION
I followed [Franciskus advice](https://github.com/Kinto/kinto-signer/issues/79#issuecomment-219637787) and added a `textarea` whose value is the current x5u chain.

It should do it, at least as a first step.

@Natim r?
