### PR TITLE
Trigger resource events on destination collection/records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,15 +6,14 @@ This document describes changes between each past release.
 0.8.0 (unreleased)
 ------------------
 
+*kinto-signer* now requires bug fixes that were released in Kinto 3.2.4 and Kinto 3.3.2.
+
 **Bug fix**
 
 - Update the `last_modified` value when updating the collection status and signature (#97)
-
-**New features**
-
 - Trigger ``ResourceChanged`` events when the destination collection and records are updated
   during signing. This allows plugins like ``kinto-changes`` and ``kinto.plugins.history``
-  to catch the changes.
+  to catch the changes (#101).
 
 
 0.7.0 (2016-06-28)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ This document describes changes between each past release.
 
 - Update the `last_modified` value when updating the collection status and signature (#97)
 
+**New features**
+
+- Trigger ``ResourceChanged`` events when the destination collection and records are updated
+  during signing. This allows plugins like ``kinto-changes`` and ``kinto.plugins.history``
+  to catch the changes.
+
 
 0.7.0 (2016-06-28)
 ------------------

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -41,7 +41,7 @@ def on_collection_changed(event, resources):
         destination=resource['destination'])
 
     try:
-        updater.sign_and_update_destination()
+        updater.sign_and_update_destination(event.request)
     except Exception:
         logger.exception("Could not sign '{0}'".format(key))
         event.request.response.status = 503

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -4,9 +4,9 @@ from kinto.core.events import ACTIONS, ResourceChanged
 from kinto import logger
 from pyramid.exceptions import ConfigurationError
 
-from kinto_signer import utils
 from kinto_signer.updater import LocalUpdater
 from kinto_signer.signer import heartbeat
+from kinto_signer import utils
 
 
 def on_collection_changed(event, resources):

--- a/kinto_signer/tests/test_events.py
+++ b/kinto_signer/tests/test_events.py
@@ -84,20 +84,18 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
 
         self._sign()
         event = [e for e in listener.received[before:]
-                 if e.payload["uri"] == self.source_collection
+                 if e.payload["resource_name"] == "collection"
+                 and e.payload["collection_id"] == "scid"
                  and e.payload["action"] == "update"][0]
-        self.assertEqual(len(event.impacted_records), 3)
-        # XXX : bug in kinto.core? should be 2 here ^
+        self.assertEqual(len(event.impacted_records), 2)
         self.assertEqual(event.impacted_records[0]["new"]["status"], "to-sign")
-        self.assertEqual(event.impacted_records[2]["new"]["status"], "signed")
+        self.assertEqual(event.impacted_records[1]["new"]["status"], "signed")
 
     def test_resource_changed_is_triggered_for_destination_collection(self):
         before = len(listener.received)
 
         self._sign()
-        # # XXX : bug in kinto.core? should be destination_collection
         event = [e for e in listener.received[before:]
-                 # if e.payload["uri"] == self.destination_collection
                  if e.payload["resource_name"] == "collection"
                  and e.payload.get("collection_id") == "dcid"
                  and e.payload["action"] == "update"][0]
@@ -110,11 +108,12 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
         before = len(listener.received)
 
         self._sign()
-        events = [e for e in listener.received[:before]
+        events = [e for e in listener.received[before:]
                   if e.payload["resource_name"] == "record"
                   and e.payload["collection_id"] == "dcid"]
 
-        self.assertEqual(len(events), 2)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(len(events[0].impacted_records), 2)
 
     def test_resource_changed_is_triggered_for_destination_removal(self):
         record_uri = self.source_collection + "/records/xyz"

--- a/kinto_signer/tests/test_events.py
+++ b/kinto_signer/tests/test_events.py
@@ -70,13 +70,13 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
     def test_resource_changed_is_triggered_for_destination_creation(self):
         self._sign()
         event = [e for e in listener.received
-                 if e.payload["uri"] == "/buckets/destination"
-                 and e.payload["action"] == "create"][0]
+                 if e.payload["uri"] == "/buckets/destination" and
+                 e.payload["action"] == "create"][0]
         self.assertEqual(len(event.impacted_records), 1)
 
         event = [e for e in listener.received
-                 if e.payload["uri"] == self.destination_collection
-                 and e.payload["action"] == "create"][0]
+                 if e.payload["uri"] == self.destination_collection and
+                 e.payload["action"] == "create"][0]
         self.assertEqual(len(event.impacted_records), 1)
 
     def test_resource_changed_is_triggered_for_source_collection(self):
@@ -84,9 +84,9 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
 
         self._sign()
         event = [e for e in listener.received[before:]
-                 if e.payload["resource_name"] == "collection"
-                 and e.payload["collection_id"] == "scid"
-                 and e.payload["action"] == "update"][0]
+                 if e.payload["resource_name"] == "collection" and
+                 e.payload["collection_id"] == "scid" and
+                 e.payload["action"] == "update"][0]
         self.assertEqual(len(event.impacted_records), 2)
         self.assertEqual(event.impacted_records[0]["new"]["status"], "to-sign")
         self.assertEqual(event.impacted_records[1]["new"]["status"], "signed")
@@ -96,9 +96,9 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
 
         self._sign()
         event = [e for e in listener.received[before:]
-                 if e.payload["resource_name"] == "collection"
-                 and e.payload.get("collection_id") == "dcid"
-                 and e.payload["action"] == "update"][0]
+                 if e.payload["resource_name"] == "collection" and
+                 e.payload.get("collection_id") == "dcid" and
+                 e.payload["action"] == "update"][0]
 
         self.assertEqual(len(event.impacted_records), 1)
         self.assertNotEqual(event.impacted_records[0]["old"].get("signature"),
@@ -109,8 +109,8 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
 
         self._sign()
         events = [e for e in listener.received[before:]
-                  if e.payload["resource_name"] == "record"
-                  and e.payload["collection_id"] == "dcid"]
+                  if e.payload["resource_name"] == "record" and
+                  e.payload["collection_id"] == "dcid"]
 
         self.assertEqual(len(events), 1)
         self.assertEqual(len(events[0].impacted_records), 2)

--- a/kinto_signer/tests/test_events.py
+++ b/kinto_signer/tests/test_events.py
@@ -1,0 +1,136 @@
+import os
+
+from kinto.tests.support import BaseWebTest, unittest
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+class Listener(object):
+    def __init__(self):
+        self.received = []
+
+    def __call__(self, event):
+        self.received.append(event)
+
+
+listener = Listener()
+
+
+def load_from_config(config, prefix):
+    return listener
+
+
+class ResourceEventsTest(BaseWebTest, unittest.TestCase):
+    def get_app_settings(self, extra=None):
+        settings = super(ResourceEventsTest, self).get_app_settings(extra)
+
+        settings['storage_backend'] = 'kinto.core.storage.memory'
+        settings['cache_backend'] = 'kinto.core.cache.memory'
+        settings['permission_backend'] = 'kinto.core.permission.memory'
+
+        settings['includes'] = 'kinto_signer'
+        settings['signer.ecdsa.private_key'] = os.path.join(
+            here, 'config', 'ecdsa.private.pem')
+
+        self.source_collection = "/buckets/alice/collections/scid"
+        self.destination_collection = "/buckets/destination/collections/dcid"
+
+        settings['signer.resources'] = '%s;%s' % (
+            self.source_collection,
+            self.destination_collection)
+
+        settings['event_listeners'] = 'ks'
+        settings['event_listeners.ks.use'] = 'kinto_signer.tests.test_events'
+        return settings
+
+    def setUp(self):
+        super(ResourceEventsTest, self).setUp()
+        self.app.put_json("/buckets/alice", headers=self.headers)
+        self.app.put_json(self.source_collection, headers=self.headers)
+        self.app.post_json(self.source_collection + "/records",
+                           {"data": {"title": "hello"}},
+                           headers=self.headers)
+        self.app.post_json(self.source_collection + "/records",
+                           {"data": {"title": "bonjour"}},
+                           headers=self.headers)
+
+    def _sign(self):
+        self.app.patch_json(self.source_collection,
+                            {"data": {"status": "to-sign"}},
+                            headers=self.headers)
+
+        resp = self.app.get(self.source_collection, headers=self.headers)
+        data = resp.json["data"]
+        self.assertEqual(data["status"], "signed")
+
+        resp = self.app.get(self.destination_collection, headers=self.headers)
+        data = resp.json["data"]
+        self.assertIn("signature", data)
+
+    def test_resource_changed_is_triggered_for_destination_creation(self):
+        self._sign()
+        event = [e for e in listener.received
+                 if e.payload["uri"] == "/buckets/destination"
+                 and e.payload["action"] == "create"][0]
+        self.assertEqual(len(event.impacted_records), 1)
+
+        event = [e for e in listener.received
+                 if e.payload["uri"] == self.destination_collection
+                 and e.payload["action"] == "create"][0]
+        self.assertEqual(len(event.impacted_records), 1)
+
+    def test_resource_changed_is_triggered_for_source_collection(self):
+        before = len(listener.received)
+
+        self._sign()
+        event = [e for e in listener.received[before:]
+                 if e.payload["uri"] == self.source_collection
+                 and e.payload["action"] == "update"][0]
+        self.assertEqual(len(event.impacted_records), 3)
+        # XXX : bug in kinto.core? should be 2 here ^
+        self.assertEqual(event.impacted_records[0]["new"]["status"], "to-sign")
+        self.assertEqual(event.impacted_records[2]["new"]["status"], "signed")
+
+    def test_resource_changed_is_triggered_for_destination_collection(self):
+        before = len(listener.received)
+
+        self._sign()
+        # # XXX : bug in kinto.core? should be destination_collection
+        event = [e for e in listener.received[before:]
+                 # if e.payload["uri"] == self.destination_collection
+                 if e.payload["resource_name"] == "collection"
+                 and e.payload.get("collection_id") == "dcid"
+                 and e.payload["action"] == "update"][0]
+
+        self.assertEqual(len(event.impacted_records), 1)
+        self.assertNotEqual(event.impacted_records[0]["old"].get("signature"),
+                            event.impacted_records[0]["new"]["signature"])
+
+    def test_resource_changed_is_triggered_for_destination_records(self):
+        before = len(listener.received)
+
+        self._sign()
+        events = [e for e in listener.received[:before]
+                  if e.payload["resource_name"] == "record"
+                  and e.payload["collection_id"] == "dcid"]
+
+        self.assertEqual(len(events), 2)
+
+    def test_resource_changed_is_triggered_for_destination_removal(self):
+        record_uri = self.source_collection + "/records/xyz"
+        self.app.put_json(record_uri,
+                          {"data": {"title": "servus"}},
+                          headers=self.headers)
+        self._sign()
+        self.app.delete(record_uri, headers=self.headers)
+
+        before = len(listener.received)
+        self._sign()
+
+        events = [e for e in listener.received[before:]
+                  if e.payload["resource_name"] == "record"]
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].payload["action"], "delete")
+        self.assertEqual(events[0].payload["uri"],
+                         self.destination_collection + "/records/xyz")

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -1,7 +1,7 @@
 from kinto.core.events import ACTIONS
 from kinto.core.storage import Filter
 from kinto.core.storage.exceptions import UnicityError, RecordNotFoundError
-from kinto.core.utils import COMPARISON, build_request, instance_uri
+from kinto.core.utils import COMPARISON, build_request
 from kinto_signer.serializer import canonical_json
 
 
@@ -207,7 +207,9 @@ class LocalUpdater(object):
                         'collection_id': self.destination['collection'],
                         'id': record['id']
                     }
-                    record_uri = instance_uri(request, 'record', **matchdict)
+                    record_uri = ('/buckets/{bucket_id}'
+                                  '/collections/{collection_id}'
+                                  '/records/{id}'.format(**matchdict))
                     notify_resource_event(
                         request,
                         {'method': 'DELETE',
@@ -231,7 +233,9 @@ class LocalUpdater(object):
                 matchdict = dict(bucket_id=self.destination['bucket'],
                                  collection_id=self.destination['collection'],
                                  id=record['id'])
-                record_uri = instance_uri(request, 'record', **matchdict)
+                record_uri = ('/buckets/{bucket_id}'
+                              '/collections/{collection_id}'
+                              '/records/{id}'.format(**matchdict))
                 notify_resource_event(
                     request,
                     {'method': 'PUT',

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -57,7 +57,8 @@ class LocalUpdater(object):
 
         # Define resource IDs.
 
-        self.destination_bucket_uri = '/buckets/%s' % self.destination['bucket']
+        self.destination_bucket_uri = '/buckets/%s' % (
+            self.destination['bucket'])
         self.destination_collection_uri = '/buckets/%s/collections/%s' % (
             self.destination['bucket'],
             self.destination['collection'])
@@ -93,7 +94,8 @@ class LocalUpdater(object):
         for event in request.get_resource_events()[before:]:
             request.registry.notify(event)
 
-    def _ensure_resource_exists(self, resource_type, parent_id, record_id, request):
+    def _ensure_resource_exists(self, resource_type, parent_id,
+                                record_id, request):
         try:
             created = self.storage.create(
                 collection_id=resource_type,
@@ -138,7 +140,6 @@ class LocalUpdater(object):
                                   parent_id=self.destination_bucket_uri,
                                   record=created,
                                   action=ACTIONS.CREATE)
-
 
         # Set the permissions on the destination collection.
         # With the current implementation, the destination is not writable by

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -1,7 +1,25 @@
-from kinto.core.utils import COMPARISON
+from pyramid import httpexceptions
+
+from kinto.core.utils import COMPARISON, build_request, instance_uri
 from kinto_signer.serializer import canonical_json
 from kinto.core.storage import Filter
-from kinto.core.storage.exceptions import UnicityError, RecordNotFoundError
+
+
+def _invoke_subrequest(request, params):
+    subrequest = build_request(request, params)
+    subrequest.bound_data = request.bound_data  # Contains resource events.
+    return request.invoke_subrequest(subrequest)
+
+
+def _ensure_resource_exists(request, uri):
+    try:
+        _invoke_subrequest(request, {
+            'method': 'PUT',
+            'path': uri,
+            'headers': {'If-None-Match': '*'}
+        })
+    except httpexceptions.HTTPPreconditionFailed:
+        pass
 
 
 class LocalUpdater(object):
@@ -41,19 +59,7 @@ class LocalUpdater(object):
         self.storage = storage
         self.permission = permission
 
-        # Define resource IDs.
-
-        self.destination_bucket_id = '/buckets/%s' % self.destination['bucket']
-        self.destination_collection_id = '/buckets/%s/collections/%s' % (
-            self.destination['bucket'],
-            self.destination['collection'])
-
-        self.source_bucket_id = '/buckets/%s' % self.source['bucket']
-        self.source_collection_id = '/buckets/%s/collections/%s' % (
-            self.source['bucket'],
-            self.source['collection'])
-
-    def sign_and_update_destination(self):
+    def sign_and_update_destination(self, request):
         """Sign the specified collection.
 
         0. Create the destination bucket / collection
@@ -64,42 +70,40 @@ class LocalUpdater(object):
            server
         5. Send the signature to the Authoritative server.
         """
-        self.create_destination()
+        before = len(request.get_resource_events())
+
+        self.create_destination(request)
         records, last_modified = self.get_source_records()
         serialized_records = canonical_json(records, last_modified)
         signature = self.signer.sign(serialized_records)
 
-        self.push_records_to_destination()
-        self.set_destination_signature(signature)
-        self.update_source_status("signed")
+        self.push_records_to_destination(request)
+        self.set_destination_signature(signature, request)
+        self.update_source_status("signed", request)
 
-    def _ensure_resource_exists(self, resource_type, parent_id, record_id):
-        try:
-            self.storage.create(
-                collection_id=resource_type,
-                parent_id=parent_id,
-                record={'id': record_id})
-        except UnicityError:
-            pass
+        # Re-trigger events from event listener \o/
+        for event in request.get_resource_events()[before:]:
+            request.registry.notify(event)
 
-    def create_destination(self):
+    def create_destination(self, request):
         # Create the destination bucket/collection if they don't already exist.
-        bucket_name = self.destination['bucket']
-        collection_name = self.destination['collection']
+        bucket_uri = instance_uri(request,
+                                  'bucket',
+                                  id=self.destination['bucket'])
+        _ensure_resource_exists(request, bucket_uri)
 
-        self._ensure_resource_exists('bucket', '', bucket_name)
-        self._ensure_resource_exists(
-            'collection',
-            self.destination_bucket_id,
-            collection_name)
+        collection_uri = instance_uri(request,
+                                      'collection',
+                                      bucket_id=self.destination['bucket'],
+                                      id=self.destination['collection'])
+        _ensure_resource_exists(request, collection_uri)
 
         # Set the permissions on the destination collection.
         # With the current implementation, the destination is not writable by
         # anyone and readable by everyone.
         # https://github.com/Kinto/kinto-signer/issues/55
         permissions = {'read': ("system.Everyone",)}
-        self.permission.replace_object_permissions(
-            self.destination_collection_id, permissions)
+        self.permission.replace_object_permissions(collection_uri, permissions)
 
     def get_source_records(self, last_modified=None, include_deleted=False):
         # If last_modified was specified, only retrieve items since then.
@@ -136,7 +140,7 @@ class LocalUpdater(object):
 
         return collection_timestamp, records_count
 
-    def push_records_to_destination(self):
+    def push_records_to_destination(self, request):
         last_modified, records_count = self.get_destination_last_modified()
         if records_count == 0:
             last_modified = None
@@ -146,60 +150,46 @@ class LocalUpdater(object):
 
         # Update the destination collection.
         for record in new_records:
+            uri = instance_uri(request, 'record',
+                               bucket_id=self.destination['bucket'],
+                               collection_id=self.destination['collection'],
+                               id=record['id'])
+
             if record.get('deleted', False):
+                uri += "?last_modified=%s" % record['last_modified']
                 try:
-                    self.storage.delete(
-                        parent_id=self.destination_collection_id,
-                        collection_id='record',
-                        object_id=record['id'],
-                        last_modified=record['last_modified']
-                    )
-                except RecordNotFoundError:
+                    _invoke_subrequest(request, {
+                        'method': 'DELETE',
+                        'path': uri
+                    })
+                except httpexceptions.HTTPNotFound:
                     # If the record doesn't exists in the destination
                     # we are good and can ignore it.
                     pass
             else:
-                self.storage.update(
-                    parent_id=self.destination_collection_id,
-                    collection_id='record',
-                    object_id=record['id'],
-                    record=record)
+                _invoke_subrequest(request, {
+                    'method': 'PUT',
+                    'path': uri,
+                    'body': {'data': record}
+                })
 
-    def set_destination_signature(self, signature):
+    def set_destination_signature(self, signature, request):
         # Push the new signature to the destination collection.
-        parent_id = '/buckets/%s' % self.destination['bucket']
-        collection_id = 'collection'
+        uri = instance_uri(request, 'collection',
+                           bucket_id=self.destination['bucket'],
+                           id=self.destination['collection'])
+        _invoke_subrequest(request, {
+            'method': 'PATCH',
+            'path': uri,
+            'body': {'data': {'signature': signature}}
+        })
 
-        collection_record = self.storage.get(
-            parent_id=parent_id,
-            collection_id=collection_id,
-            object_id=self.destination['collection'])
-
-        # Update the collection_record
-        del collection_record['last_modified']
-        collection_record['signature'] = signature
-
-        self.storage.update(
-            parent_id=parent_id,
-            collection_id=collection_id,
-            object_id=self.destination['collection'],
-            record=collection_record)
-
-    def update_source_status(self, status):
-        parent_id = '/buckets/%s' % self.source['bucket']
-        collection_id = 'collection'
-
-        collection_record = self.storage.get(
-            parent_id=parent_id,
-            collection_id=collection_id,
-            object_id=self.source['collection'])
-
-        # Update the collection_record
-        del collection_record['last_modified']
-        collection_record['status'] = status
-
-        self.storage.update(
-            parent_id=parent_id,
-            collection_id=collection_id,
-            object_id=self.source['collection'],
-            record=collection_record)
+    def update_source_status(self, status, request):
+        uri = instance_uri(request, 'collection',
+                           bucket_id=self.source['bucket'],
+                           id=self.source['collection'])
+        _invoke_subrequest(request, {
+            'method': 'PATCH',
+            'path': uri,
+            'body': {'data': {'status': 'signed'}}
+        })

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ enum34==1.1.6
 functools32==3.2.3.post2
 iso8601==0.1.11
 jsonschema==2.5.1
-kinto==3.3.0
+kinto==3.3.2
 mohawk==0.3.2.1
 PasteDeploy==1.5.2
 pyramid==1.7

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     README = f.read()
 
 REQUIREMENTS = [
-    'kinto',
+    'kinto>=3.2.4',
     'ecdsa',
     'requests-hawk',
 ]


### PR DESCRIPTION
This is major rewrite of the updater in order to trigger `ResourceChanged` events when the destination collection/records are updated (on signing).

The challenges are:
* Leverage the resource code that builds and sends events
* Trigger a `ResourceChanged` from a `ResourceChanged` may not be natural :)
* Rewrite the tests since they rely on mocks and are broken

I chose to go with invoque_subrequest() instead of the kind of [awful code](https://github.com/Kinto/kinto/blob/3.3.1/kinto/plugins/default_bucket/__init__.py#L67-L113) we currently have in the default bucket plugin.

I find the result convincing and promising (most events tests pass), but I need feedback :)

@almet @Natim f?
