### PR TITLE
Use a dedicated errno in 403 responses when operation is forbidden (Fixes #135)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ This document describes changes between each past release.
 
 - Fix decoration of listener when StatsD is enabled (fixes #138)
   Related to https://github.com/jsocol/pystatsd/issues/85
+- Use a dedicated ``errno`` in 403 responses when operation is forbidden (fixes #135)
 
 
 0.9.1 (2016-10-03)

--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -3,6 +3,7 @@ from kinto.core import errors
 
 from kinto import logger
 from kinto.core.utils import instance_uri
+from kinto.core.errors import ERRORS
 from pyramid import httpexceptions
 
 from kinto_signer.updater import (LocalUpdater, FIELD_LAST_AUTHOR,
@@ -10,18 +11,21 @@ from kinto_signer.updater import (LocalUpdater, FIELD_LAST_AUTHOR,
 from kinto_signer.utils import STATUS
 
 
+ERRNO_FORBIDDEN_OPERATION = 123
 _PLUGIN_USERID = "plugin:kinto-signer"
 
 
 def raise_invalid(**kwargs):
     # A ``400`` error response does not natively rollback the transaction.
     transaction.doom()
+    kwargs.update(errno=ERRORS.INVALID_POSTED_DATA)
     raise errors.http_error(httpexceptions.HTTPBadRequest(), **kwargs)
 
 
 def raise_forbidden(**kwargs):
     # A ``403`` error response does not natively rollback the transaction.
     transaction.doom()
+    kwargs.update(errno=ERRNO_FORBIDDEN_OPERATION)
     raise errors.http_error(httpexceptions.HTTPForbidden(), **kwargs)
 
 

--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -11,7 +11,6 @@ from kinto_signer.updater import (LocalUpdater, FIELD_LAST_AUTHOR,
 from kinto_signer.utils import STATUS
 
 
-ERRNO_FORBIDDEN_OPERATION = 123
 _PLUGIN_USERID = "plugin:kinto-signer"
 
 
@@ -25,7 +24,7 @@ def raise_invalid(**kwargs):
 def raise_forbidden(**kwargs):
     # A ``403`` error response does not natively rollback the transaction.
     transaction.doom()
-    kwargs.update(errno=ERRNO_FORBIDDEN_OPERATION)
+    kwargs.update(errno=ERRORS.FORBIDDEN)
     raise errors.http_error(httpexceptions.HTTPForbidden(), **kwargs)
 
 

--- a/tests/test_signoff_flow.py
+++ b/tests/test_signoff_flow.py
@@ -3,6 +3,7 @@ import unittest
 import mock
 
 from kinto.core.testing import FormattedErrorMixin
+from kinto.core.errors import ERRORS
 from .support import BaseWebTest, get_user_headers
 
 
@@ -85,7 +86,7 @@ class CollectionStatusTest(PostgresWebTest, FormattedErrorMixin, unittest.TestCa
                                    status=400)
         self.assertFormattedError(response=resp,
                                   code=400,
-                                  errno=109,
+                                  errno=ERRORS.INVALID_POSTED_DATA,
                                   error="Bad Request",
                                   message="Invalid status 'married'")
         resp = self.app.get(self.source_collection, headers=self.headers)
@@ -323,7 +324,7 @@ class UserGroupsTest(PostgresWebTest, FormattedErrorMixin, unittest.TestCase):
                                    status=403)
         self.assertFormattedError(response=resp,
                                   code=403,
-                                  errno=121,
+                                  errno=ERRORS.FORBIDDEN,
                                   error="Forbidden",
                                   message="Not in editors group")
 
@@ -342,7 +343,7 @@ class UserGroupsTest(PostgresWebTest, FormattedErrorMixin, unittest.TestCase):
                                    status=403)
         self.assertFormattedError(response=resp,
                                   code=403,
-                                  errno=121,
+                                  errno=ERRORS.FORBIDDEN,
                                   error="Forbidden",
                                   message="Not in reviewers group")
 

--- a/tests/test_signoff_flow.py
+++ b/tests/test_signoff_flow.py
@@ -317,7 +317,7 @@ class UserGroupsTest(PostgresWebTest, unittest.TestCase):
                                    headers=self.reviewer_headers,
                                    status=403)
         assert "Not in editors group" in resp.json["message"]
-        assert resp.json["errno"] == 123
+        assert resp.json["errno"] == 121  # forbidden
 
         self.app.patch_json(self.source_collection,
                             {"data": {"status": "to-review"}},
@@ -333,7 +333,7 @@ class UserGroupsTest(PostgresWebTest, unittest.TestCase):
                                    headers=self.editor_headers,
                                    status=403)
         assert "Not in reviewers group" in resp.json["message"]
-        assert resp.json["errno"] == 123
+        assert resp.json["errno"] == 121  # forbidden
 
         self.app.patch_json(self.source_collection,
                             {"data": {"status": "to-sign"}},


### PR DESCRIPTION
Fixes #135
 
r? @Natim 