### PR TITLE
Prevent recursivity for to-review

### DIFF
--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -44,7 +44,10 @@ def sign_collection_data(event, resources):
         # Ignore changes made by plugin.
         return
 
-    for impacted in event.impacted_records:
+    # Prevent recursivity, since the following operations will alter the current collection.
+    impacted_records = tuple(event.impacted_records)
+
+    for impacted in impacted_records:
         new_collection = impacted['new']
 
         key = instance_uri(event.request, "collection",


### PR DESCRIPTION
Did not figure out how to test properly, but this is a bug.

**Notes**: the line `updater.update_source_editor(event.request)` is supposed to trigger an event, but it gets grouped with the current event and an impacted record is added to the list. This causes the loop to be executed twice, possibly executing `updater.sign_and_update_destination()` twice on the preview collection