### PR TITLE
e2e: get_records now returns an iterator

### DIFF
--- a/scripts/e2e.py
+++ b/scripts/e2e.py
@@ -208,7 +208,7 @@ def main():
 
     # 6. obtain the destination records and serialize canonically.
 
-    records = dest_client.get_records()
+    records = list(dest_client.get_records())
     assert len(records) == expected, '%s != %s records' % (len(records), expected)
     timestamp = collection_timestamp(dest_client)
     serialized = canonical_json(records, timestamp)


### PR DESCRIPTION
This is a quick hack to try to get kinto-dist to build.

canonical_json does a `copy.deepcopy` on its argument, although it isn't exactly clear why, since it never modifies it. Either way, though, we still ought to make sure that it handles sequences (i.e. iterators more robustly).