### PR TITLE
Update to autograph v2 response format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
     - tox -e $TOX_ENV
 matrix:
   include:
-    - go: 1.6
+    - go: 1.8
       language: go
       addons:
         postgresql: "9.5"
@@ -34,7 +34,7 @@ matrix:
         - make install
         - make run-autograph &
         - make run-kinto &
-    - go: 1.6
+    - go: 1.8
       language: go
       addons:
         postgresql: "9.5"

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ run-kinto: install-dev
 install-autograph: $(VENV)/bin/autograph
 
 $(VENV)/bin/autograph:
-	export GOPATH=$(VENV); export PATH="$$GOPATH/bin;$$PATH"; go get -d -u github.com/mozilla-services/autograph; cd $(VENV)/src/github.com/mozilla-services/autograph/; git checkout 1.3.2; go get github.com/mozilla-services/autograph
+	export GOPATH=$(VENV); export PATH="$$GOPATH/bin;$$PATH"; go get -u github.com/mozilla-services/autograph
 
 run-autograph: install-autograph
 	$(VENV)/bin/autograph -c tests/config/autograph.yaml

--- a/README.rst
+++ b/README.rst
@@ -305,12 +305,9 @@ The *destination* collection metadata now contains the signature:
            "id": "collection1",
            "last_modified": 1460558496510,
            "signature": {
-               "public_key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4k3FmG7dFoOt3Tuzl76abTRtK8sb/r/ibCSeVKa96RbrOX2ciscz/TT8wfqBYS/8cN4zMe1+f7wRmkNrCUojZR1ZKmYM2BeiUOMlMoqk2O7+uwsn1DwNQSYP58TkvZt6",
-               "ref": "939wa3q3s3vn20rddhq8lb5ie",
-               "algorithm": "p384ecdsa",
+               "mode": "p384ecdsa",
                "x5u": "https://bucket.example.net/appkey1.pem",
-               "signature": "Nv-EJ1D0fanElBGP4ZZmV6zu_b4DuCP3H7xawlLrcR7to3aKzqfZknVXOi94G_w8-wdKlysVWmhuDMqJqPcJV7ZudbhypJpj7kllWdPvMRZkoWXSfYLaoLMc8VQEqZcb",
-               "content-signature": "x5u=https://bucket.example.net/appkey1.pem;p384ecdsa=Nv-EJ1D0fanElBGP4ZZmV6zu_b4DuCP3H7xawlLrcR7to3aKzqfZknVXOi94G_w8-wdKlysVWmhuDMqJqPcJV7ZudbhypJpj7kllWdPvMRZkoWXSfYLaoLMc8VQEqZcb"
+               "signature": "Nv-EJ1D0fanElBGP4ZZmV6zu_b4DuCP3H7xawlLrcR7to3aKzqfZknVXOi94G_w8-wdKlysVWmhuDMqJqPcJV7ZudbhypJpj7kllWdPvMRZkoWXSfYLaoLMc8VQEqZcb"
            }
        },
        "permissions": {

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Kinto signer
     :target: https://coveralls.io/github/Kinto/kinto-signer?branch=master
 
 **Kinto signer** is a `Kinto <https://kinto.readthedocs.io>`_ plugin
-that introduces `digital signatures <https://en.wikipedia.org/wiki/Digital_signature>`_
-in order to guarantee integrity and authenticity of collections of records.
+that signs records with a `content signatures <https://github.com/mozilla-services/autograph/blob/master/signer/contentsignature/README.rst>`_
+to guarantee their integrity and authenticity.
 
 
 How does it work?
@@ -52,7 +52,7 @@ with the P-384 strength.
 * The signature is produced with ECDSA on P-384 using SHA-384.
 * The signature is returned as encoded using URL-safe variant of base-64.
 
-See `Internet-Draft for P-384/ECDSA <https://github.com/martinthomson/content-signature/pull/2/files>`_
+See `Content Signature <https://github.com/mozilla-services/autograph/blob/master/signer/contentsignature/README.rst>`_
 
 The content signature is validated in Firefox using the `Personal Security Manager <https://developer.mozilla.org/en/docs/Mozilla/Projects/PSM>`_.
 
@@ -305,13 +305,9 @@ The *destination* collection metadata now contains the signature:
            "id": "collection1",
            "last_modified": 1460558496510,
            "signature": {
-               "hash_algorithm": "sha384",
                "public_key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4k3FmG7dFoOt3Tuzl76abTRtK8sb/r/ibCSeVKa96RbrOX2ciscz/TT8wfqBYS/8cN4zMe1+f7wRmkNrCUojZR1ZKmYM2BeiUOMlMoqk2O7+uwsn1DwNQSYP58TkvZt6",
                "ref": "939wa3q3s3vn20rddhq8lb5ie",
-               "signature": "oGkEfZOegNeYxHjDkc_TnUixX4BzESOzxd2OMn63rKBZL9FR3gjrRj7tmu8BWpnuWSLdH_aIjBsKsq4Dmg7XdDczeg86owSl5L-UYtKW3g4B4Yrh-yJZZFhchRbmZea6",
-               "signature_encoding": "rs_base64url"
-               "content-signature": "x5u=https://bucket.example.net/appkey1.pem;p384ecdsa=Nv-EJ1D0fanElBGP4ZZmV6zu_b4DuCP3H7xawlLrcR7to3aKzqfZknVXOi94G_w8-wdKlysVWmhuDMqJqPcJV7ZudbhypJpj7kllWdPvMRZkoWXSfYLaoLMc8VQEqZcb",
-               "x5u": "https://bucket.example.net/appkey1.pem",
+               "signature": "x5u=https://bucket.example.net/appkey1.pem;p384ecdsa=Nv-EJ1D0fanElBGP4ZZmV6zu_b4DuCP3H7xawlLrcR7to3aKzqfZknVXOi94G_w8-wdKlysVWmhuDMqJqPcJV7ZudbhypJpj7kllWdPvMRZkoWXSfYLaoLMc8VQEqZcb"
            }
        },
        "permissions": {

--- a/README.rst
+++ b/README.rst
@@ -307,7 +307,10 @@ The *destination* collection metadata now contains the signature:
            "signature": {
                "public_key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4k3FmG7dFoOt3Tuzl76abTRtK8sb/r/ibCSeVKa96RbrOX2ciscz/TT8wfqBYS/8cN4zMe1+f7wRmkNrCUojZR1ZKmYM2BeiUOMlMoqk2O7+uwsn1DwNQSYP58TkvZt6",
                "ref": "939wa3q3s3vn20rddhq8lb5ie",
-               "signature": "x5u=https://bucket.example.net/appkey1.pem;p384ecdsa=Nv-EJ1D0fanElBGP4ZZmV6zu_b4DuCP3H7xawlLrcR7to3aKzqfZknVXOi94G_w8-wdKlysVWmhuDMqJqPcJV7ZudbhypJpj7kllWdPvMRZkoWXSfYLaoLMc8VQEqZcb"
+               "algorithm": "p384ecdsa",
+               "x5u": "https://bucket.example.net/appkey1.pem",
+               "signature": "Nv-EJ1D0fanElBGP4ZZmV6zu_b4DuCP3H7xawlLrcR7to3aKzqfZknVXOi94G_w8-wdKlysVWmhuDMqJqPcJV7ZudbhypJpj7kllWdPvMRZkoWXSfYLaoLMc8VQEqZcb",
+               "content-signature": "x5u=https://bucket.example.net/appkey1.pem;p384ecdsa=Nv-EJ1D0fanElBGP4ZZmV6zu_b4DuCP3H7xawlLrcR7to3aKzqfZknVXOi94G_w8-wdKlysVWmhuDMqJqPcJV7ZudbhypJpj7kllWdPvMRZkoWXSfYLaoLMc8VQEqZcb"
            }
        },
        "permissions": {

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Kinto signer
     :target: https://coveralls.io/github/Kinto/kinto-signer?branch=master
 
 **Kinto signer** is a `Kinto <https://kinto.readthedocs.io>`_ plugin
-that signs records with a `content signatures <https://github.com/mozilla-services/autograph/blob/master/signer/contentsignature/README.rst>`_
+that signs records with a `content signature <https://github.com/mozilla-services/autograph/blob/e7c33d6/signer/contentsignature/README.rst>`_
 to guarantee their integrity and authenticity.
 
 
@@ -52,7 +52,7 @@ with the P-384 strength.
 * The signature is produced with ECDSA on P-384 using SHA-384.
 * The signature is returned as encoded using URL-safe variant of base-64.
 
-See `Content Signature <https://github.com/mozilla-services/autograph/blob/master/signer/contentsignature/README.rst>`_
+See `Content Signature <https://github.com/mozilla-services/autograph/blob/e7c33d6/signer/contentsignature/README.rst>`_
 
 The content signature is validated in Firefox using the `Personal Security Manager <https://developer.mozilla.org/en/docs/Mozilla/Projects/PSM>`_.
 

--- a/kinto_signer/signer/__init__.py
+++ b/kinto_signer/signer/__init__.py
@@ -1,8 +1,7 @@
 from kinto import logger
 
 
-EXPECTED_FIELDS = ["content-signature", "signature", "hash_algorithm",
-                   "signature_encoding", "x5u"]
+EXPECTED_FIELDS = ["signature", "public_key", "type"]
 
 
 def heartbeat(request):

--- a/kinto_signer/signer/__init__.py
+++ b/kinto_signer/signer/__init__.py
@@ -1,7 +1,7 @@
 from kinto import logger
 
 
-EXPECTED_FIELDS = ["signature", "public_key", "type"]
+EXPECTED_FIELDS = ["content-signature", "signature", "x5u", "public_key", "type"]
 
 
 def heartbeat(request):

--- a/kinto_signer/signer/__init__.py
+++ b/kinto_signer/signer/__init__.py
@@ -1,7 +1,7 @@
 from kinto import logger
 
 
-EXPECTED_FIELDS = ["content-signature", "signature", "x5u", "public_key", "type"]
+EXPECTED_FIELDS = ["signature", "x5u", "mode"]
 
 
 def heartbeat(request):

--- a/kinto_signer/signer/__init__.py
+++ b/kinto_signer/signer/__init__.py
@@ -14,7 +14,7 @@ def heartbeat(request):
     """
     for signer in request.registry.signers.values():
         try:
-            result = signer.sign("TEST")
+            result = signer.sign("This is an heartbeat tests.")
             expected = set(EXPECTED_FIELDS)
             obtained = result.keys()
             if len(expected.intersection(obtained)) != len(EXPECTED_FIELDS):

--- a/kinto_signer/signer/autograph.py
+++ b/kinto_signer/signer/autograph.py
@@ -21,13 +21,10 @@ class AutographSigner(SignerBase):
         b64_payload = base64.b64encode(payload)
         url = urljoin(self.server_url, '/sign/data')
         resp = requests.post(url, auth=self.auth, json=[{
-            "input": b64_payload.decode('utf-8'),
-            "template": "content-signature",
-            "hashwith": "sha384"
+            "input": b64_payload.decode('utf-8')
         }])
         resp.raise_for_status()
         signature_bundle = resp.json()[0]
-        signature_bundle.setdefault('signature_encoding', 'rs_base64url')
         return signature_bundle
 
 

--- a/kinto_signer/signer/local_ecdsa.py
+++ b/kinto_signer/signer/local_ecdsa.py
@@ -51,19 +51,15 @@ class ECDSASigner(SignerBase):
 
         payload = self.prefix + payload
         private_key = self.load_private_key()
-        public_key = self.load_public_key()
         signature = private_key.sign(payload,
                                      hashfunc=hashlib.sha384,
                                      sigencode=ecdsa.util.sigencode_string)
         x5u = ''
         enc_signature = base64.urlsafe_b64encode(signature).decode('utf-8')
-        public_key = base64.urlsafe_b64encode(public_key.to_string()).decode('utf-8')
         return {
             'signature': enc_signature,
             'x5u': x5u,
-            'public_key': public_key,
-            'content-signature': 'x5u=%s;p384ecdsa=%s' % (x5u, enc_signature),
-            'type': 'contentsignature'
+            'mode': 'p384ecdsa'
         }
 
     def verify(self, payload, signature_bundle):

--- a/tests/config/autograph.yaml
+++ b/tests/config/autograph.yaml
@@ -8,6 +8,7 @@ signers:
     # a p384 key, the standard
     - id: appkey1
       type: contentsignature
+      x5u: https://bucket.example.net/appkey1.pem
       privatekey: |
           -----BEGIN EC PARAMETERS-----
           BgUrgQQAIg==
@@ -21,6 +22,7 @@ signers:
     
     - id: appkey2
       type: contentsignature
+      x5u: https://bucket.example.net/appkey2.pem
       privatekey: |
           -----BEGIN EC PRIVATE KEY-----
           MIGkAgEBBDDzB8n4AOghssIP8Y1/qBLAh3uW8w5i75fZG6qQDTGbOGZbpooeQvdk

--- a/tests/config/autograph.yaml
+++ b/tests/config/autograph.yaml
@@ -13,17 +13,32 @@ signers:
           BgUrgQQAIg==
           -----END EC PARAMETERS-----
           -----BEGIN EC PRIVATE KEY-----
-          MIGkAgEBBDART/nn3fKlhyENdc2u3klbvRJ5+odP0kWzt9p+v5hDyggbtVA4M1Mb
-          fL9KoaiAAv2gBwYFK4EEACKhZANiAATugz97A6HPqq0fJCGom9PdKJ58Y9aobARQ
-          BkZWS5IjC+15Uqt3yOcCMdjIJpikiD1WjXRaeFe+b3ovcoBs4ToLK7d8y0qFlkgx
-          /5Cp6z37rpp781N4haUOIauM14P4KUw=
+          MIGkAgEBBDAzX2TrGOr0WE92AbAl+nqnpqh25pKCLYNMTV2hJHztrkVPWOp8w0mh
+          scIodK8RMpagBwYFK4EEACKhZANiAATiTcWYbt0Wg63dO7OXvpptNG0ryxv+v+Js
+          JJ5Upr3pFus5fZyKxzP9NPzB+oFhL/xw3jMx7X5/vBGaQ2sJSiNlHVkqZgzYF6JQ
+          4yUyiqTY7v67CyfUPA1BJg/nxOS9m3o=
           -----END EC PRIVATE KEY-----
+    
+    - id: appkey2
+      type: contentsignature
+      privatekey: |
+          -----BEGIN EC PRIVATE KEY-----
+          MIGkAgEBBDDzB8n4AOghssIP8Y1/qBLAh3uW8w5i75fZG6qQDTGbOGZbpooeQvdk
+          agQT/dt8/KqgBwYFK4EEACKhZANiAARBmh+6Wc7CvAWylhyEsw5CMy7eSC5nfOo9
+          rszb+aoRxxe/PFrebfgqIBGx8EpXN+DT6QX5dZTLqcjj7GMWx50UvJ1+kIKTLbUx
+          +8Q7KIqH8pQ40GJbFySJS01LyNkqgqc=
+          -----END EC PRIVATE KEY-----
+    
 
 authorizations:
     - id: alice
       key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
       signers:
           - appkey1
+    - id: bob
+      key: 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d
+      signers:
+          - appkey2
 
 monitoring:
     key: 19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs

--- a/tests/config/autograph.yaml
+++ b/tests/config/autograph.yaml
@@ -1,22 +1,29 @@
 server:
-    listen: "localhost:8000"
+    listen: "0.0.0.0:8000"
     # cache 500k nonces to protect from authorization replay attacks
     noncecachesize: 524288
 
+# The keys below are testing keys that do not grant any power
 signers:
+    # a p384 key, the standard
     - id: appkey1
-      privatekey: "MIGkAgEBBDAzX2TrGOr0WE92AbAl+nqnpqh25pKCLYNMTV2hJHztrkVPWOp8w0mhscIodK8RMpagBwYFK4EEACKhZANiAATiTcWYbt0Wg63dO7OXvpptNG0ryxv+v+JsJJ5Upr3pFus5fZyKxzP9NPzB+oFhL/xw3jMx7X5/vBGaQ2sJSiNlHVkqZgzYF6JQ4yUyiqTY7v67CyfUPA1BJg/nxOS9m3o="
-      x5u: https://bucket.example.net/appkey1.pem
-    - id: appkey2
-      privatekey: "MIGkAgEBBDDzB8n4AOghssIP8Y1/qBLAh3uW8w5i75fZG6qQDTGbOGZbpooeQvdkagQT/dt8/KqgBwYFK4EEACKhZANiAARBmh+6Wc7CvAWylhyEsw5CMy7eSC5nfOo9rszb+aoRxxe/PFrebfgqIBGx8EpXN+DT6QX5dZTLqcjj7GMWx50UvJ1+kIKTLbUx+8Q7KIqH8pQ40GJbFySJS01LyNkqgqc="
-      x5u: https://bucket.example.net/appkey2.pem
+      type: contentsignature
+      privatekey: |
+          -----BEGIN EC PARAMETERS-----
+          BgUrgQQAIg==
+          -----END EC PARAMETERS-----
+          -----BEGIN EC PRIVATE KEY-----
+          MIGkAgEBBDART/nn3fKlhyENdc2u3klbvRJ5+odP0kWzt9p+v5hDyggbtVA4M1Mb
+          fL9KoaiAAv2gBwYFK4EEACKhZANiAATugz97A6HPqq0fJCGom9PdKJ58Y9aobARQ
+          BkZWS5IjC+15Uqt3yOcCMdjIJpikiD1WjXRaeFe+b3ovcoBs4ToLK7d8y0qFlkgx
+          /5Cp6z37rpp781N4haUOIauM14P4KUw=
+          -----END EC PRIVATE KEY-----
 
 authorizations:
     - id: alice
       key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
       signers:
           - appkey1
-    - id: bob
-      key: 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d
-      signers:
-          - appkey2
+
+monitoring:
+    key: 19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -70,10 +70,10 @@ class HeartbeatTest(BaseWebTest, unittest.TestCase):
         self.mock = patch.start()
         self.addCleanup(patch.stop)
         self.signature = {"signature": "",
-                          "hash_algorithm": "",
-                          "signature_encoding": "",
                           "content-signature": "",
-                          "x5u": ""}
+                          "public_key": "",
+                          "x5u": "",
+                          "type": ""}
         self.mock.post.return_value.json.return_value = [self.signature]
 
     def test_heartbeat_is_exposed(self):

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -69,11 +69,7 @@ class HeartbeatTest(BaseWebTest, unittest.TestCase):
         patch = mock.patch('kinto_signer.signer.autograph.requests')
         self.mock = patch.start()
         self.addCleanup(patch.stop)
-        self.signature = {"signature": "",
-                          "content-signature": "",
-                          "public_key": "",
-                          "x5u": "",
-                          "type": ""}
+        self.signature = {"signature": "", "x5u": "", "mode": ""}
         self.mock.post.return_value.json.return_value = [self.signature]
 
     def test_heartbeat_is_exposed(self):

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,4 +1,4 @@
-from base64 import b64decode, urlsafe_b64encode
+from base64 import urlsafe_b64decode, urlsafe_b64encode
 import tempfile
 import re
 import os
@@ -67,7 +67,7 @@ class ECDSASignerTest(unittest.TestCase):
         signature_bundle = self.signer.sign("this is some text")
         b64signature = signature_bundle['signature']
 
-        decoded_signature = b64decode(b64signature.encode('utf-8'))
+        decoded_signature = urlsafe_b64decode(b64signature.encode('utf-8'))
         b64urlsignature = urlsafe_b64encode(decoded_signature).decode('utf-8')
         signature_bundle['signature'] = b64urlsignature
         signature_bundle['signature_encoding'] = 'rs_base64url'
@@ -77,8 +77,7 @@ class ECDSASignerTest(unittest.TestCase):
     def test_wrong_signature_raises_an_error(self):
         signature_bundle = {
             'signature': SIGNATURE,
-            'hash_algorithm': 'sha384',
-            'signature_encoding': 'rs_base64'}
+            'mode': 'p384ecdsa'}
 
         with pytest.raises(exceptions.BadSignatureError):
             self.signer.verify(
@@ -87,10 +86,7 @@ class ECDSASignerTest(unittest.TestCase):
 
     def test_signer_returns_a_base64_string(self):
         signature = self.signer.sign("this is some text")['signature']
-        hexa_regexp = (
-            r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}'
-            '==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$')
-        assert re.match(hexa_regexp, signature) is not None
+        urlsafe_b64decode(signature.encode('utf-8'))  # Raise if wrong.
 
     def test_load_private_key_raises_if_no_key_specified(self):
         with pytest.raises(ValueError):

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,6 +1,5 @@
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 import tempfile
-import re
 import os
 import unittest
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -14,7 +14,7 @@ from kinto_signer.signer import local_ecdsa
 
 SIGNATURE = (
     "ikfq6qOV85vR7QaNCTldVvvtcNpPIICqqMp3tfyiT7fHCgFNq410SFnIfjAPgSa"
-    "jEtxxyGtZFMoI/BzO/1y5oShLtX0LH4wx/Wft7wz17T7fFqpDQ9hFZzTOPBwZUIbx")
+    "jEtxxyGtZFMoI_BzO_1y5oShLtX0LH4wx_Wft7wz17T7fFqpDQ9hFZzTOPBwZUIbx")
 
 
 def save_key(key, key_name):

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -85,30 +85,6 @@ class ECDSASignerTest(unittest.TestCase):
                 "Text not matching with the sig.",
                 signature_bundle)
 
-    def test_unsupported_hash_algorithm_raises(self):
-        signature_bundle = {
-            'signature': SIGNATURE,
-            'hash_algorithm': 'sha256',
-            'signature_encoding': 'rs_base64'}
-
-        with pytest.raises(ValueError) as excinfo:
-            self.signer.verify(
-                "Text not matching with the sig.",
-                signature_bundle)
-        assert str(excinfo.value) == "Unsupported hash_algorithm: sha256"
-
-    def test_unsupported_signature_encoding_raises(self):
-        signature_bundle = {
-            'signature': SIGNATURE,
-            'hash_algorithm': 'sha384',
-            'signature_encoding': 'base64'}
-
-        with pytest.raises(ValueError) as excinfo:
-            self.signer.verify(
-                "Text not matching with the sig.",
-                signature_bundle)
-        assert str(excinfo.value) == "Unsupported signature_encoding: base64"
-
     def test_signer_returns_a_base64_string(self):
         signature = self.signer.sign("this is some text")['signature']
         hexa_regexp = (
@@ -170,9 +146,7 @@ class AutographSignerTest(unittest.TestCase):
         requests.post.assert_called_with(
             'http://localhost:8000/sign/data',
             auth=self.signer.auth,
-            json=[{'hashwith': 'sha384',
-                   'input': 'dGVzdCBkYXRh',
-                   'template': 'content-signature'}])
+            json=[{'input': 'dGVzdCBkYXRh'}])
         assert signature_bundle['signature'] == SIGNATURE
 
     @mock.patch('kinto_signer.signer.autograph.AutographSigner')


### PR DESCRIPTION
This is a work in progress, do not merge yet.
It is tied to https://github.com/mozilla-services/autograph/pull/46

The `content-signature` is being moved into the `signature` field and need to be parse before being decoded and verified. It's a minor change, and will also ensure that the content signature we're giving the users is the one we're verifying.