### PR TITLE
Send kinto-signer events before commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,10 @@ This document describes changes between each past release.
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Send kinto-signer before committing since some database may have to be performed
+  in the subscribers (#172)
 
 
 1.3.1 (2017-03-17)

--- a/README.rst
+++ b/README.rst
@@ -343,6 +343,12 @@ The following events are thrown:
 * ``kinto_signer.events.ReviewRejected``
 * ``kinto_signer.events.ReviewApproved``
 
+.. important::
+
+    The events are sent within the request's transaction. In other words, any
+    database change that occurs in subscribers will be committed or rolledback
+    depending of the overall response status.
+
 
 Validating the signature
 ========================


### PR DESCRIPTION
We used to send the events on `AfterResourceChanged`. The `ResourceChanged` events were thus emitted out of the request transaction. Introducing inconsistencies in the way subscribers had to manage the manual commit when performing database changes.