### PR TITLE
Invalidate cache for blocklist XML paths.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,12 @@ Changelog
 
 This document describes changes between each past release.
 
-2.2.0 (unreleased)
+2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Invalidate kinto-amo blocklist paths in the CDN.
 
 
 2.1.0 (2017-08-07)

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -399,6 +399,14 @@ class LocalUpdater(object):
     def invalidate_cloudfront_cache(self, request, timestamp):
         collection_path = "/v1%s*" % self.destination_collection_uri
         monitor_path = "/v1/buckets/monitor/collections/changes*"
+
+        paths = [collection_path, monitor_path]
+
+        if self.destination_collection_uri.startswith('/buckets/blocklists/'):
+            paths.append('/v1/blocklist/*')
+        elif self.destination_collection_uri.startswith('/buckets/blocklists-preview/'):
+            paths.append('/v1/preview/*')
+
         distribution_id = request.registry.settings.get('signer.distribution_id')
 
         if distribution_id:
@@ -413,10 +421,7 @@ class LocalUpdater(object):
                     InvalidationBatch={
                         'Paths': {
                             'Quantity': 2,
-                            'Items': [
-                                collection_path,
-                                monitor_path
-                            ]
+                            'Items': paths
                         },
                         'CallerReference': '{}-{}'.format(timestamp, uuid.uuid4())
                     })

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -420,7 +420,7 @@ class LocalUpdater(object):
                     DistributionId=distribution_id,
                     InvalidationBatch={
                         'Paths': {
-                            'Quantity': 2,
+                            'Quantity': len(paths),
                             'Items': paths
                         },
                         'CallerReference': '{}-{}'.format(timestamp, uuid.uuid4())

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -271,7 +271,7 @@ class LocalUpdaterTest(unittest.TestCase):
             assert params['DistributionId'] == "DWIGHTENIS"
             assert params['InvalidationBatch']['CallerReference'].startswith('tz_1234-')
             assert params['InvalidationBatch']['Paths'] == {
-                'Quantity': 2,
+                'Quantity': 3,
                 'Items': ['/v1/buckets/blocklists/collections/destcollection*',
                           '/v1/buckets/monitor/collections/changes*',
                           '/v1/blocklist/*']
@@ -297,7 +297,7 @@ class LocalUpdaterTest(unittest.TestCase):
             assert params['DistributionId'] == "DWIGHTENIS"
             assert params['InvalidationBatch']['CallerReference'].startswith('tz_1234-')
             assert params['InvalidationBatch']['Paths'] == {
-                'Quantity': 2,
+                'Quantity': 3,
                 'Items': ['/v1/buckets/blocklists-preview/collections/destcollection*',
                           '/v1/buckets/monitor/collections/changes*',
                           '/v1/preview/*']


### PR DESCRIPTION
Maybe this should be handled in the kinto-amo plugin also the kinto-amo plugin is not necessarily on the kinto-writer. Let's discuss that with @leplatrem 