### PR TITLE
Drop legacy underscore prefix in settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ This document describes changes between each past release.
 2.3.0 (unreleased)
 ------------------
 
+**Breaking changes**
+
+- The settings ``reviewers_group``, ``editors_group``, ``to_review_enabled``, ``group_check_enabled``
+  prefixed with ``_`` are not supported anymore. (eg. use ``kinto.signer.staging_certificates.editors_group``
+  instead of ``kinto.signer.staging_certificates_editors_group``)
+
 **New features**
 
 - Allow configuration of ``reviewers_group``, ``editors_group``, ``to_review_enabled``, ``group_check_enabled``

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -77,8 +77,7 @@ def includeme(config):
         for setting in ("reviewers_group", "editors_group",
                         "to_review_enabled", "group_check_enabled"):
             # Legacy format with _ separation between prefix and setting name.
-            value = settings.get("signer.%s.%s" % (collection_wide, setting),
-                                 settings.get("signer.%s_%s" % (collection_wide, setting)))
+            value = settings.get("signer.%s.%s" % (collection_wide, setting))
             if value is None:
                 # By bucket or globally.
                 value = settings.get("signer.%s.%s" % (bucket_wide, setting))


### PR DESCRIPTION
Requires https://github.com/mozilla-services/cloudops-deployment/pull/1623 to be merged and deployed before upgrading prod to this version.