### PR TITLE
[do-not-merge] Use principals instead of groups in settings (fixes #205)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ This document describes changes between each past release.
 2.3.0 (unreleased)
 ------------------
 
+**Breaking changes**
+
+- The settings ``reviewers_group``, ``editors_group``, ``to_review_enabled``, ``group_check_enabled``
+  prefixed with ``_`` are not supported anymore. (eg. use ``kinto.signer.staging_certificates.editors_group``
+  instead of ``kinto.signer.staging_certificates_editors_group``)
+
 **New features**
 
 - Allow configuration of ``reviewers_group``, ``editors_group``, ``to_review_enabled``, ``group_check_enabled``

--- a/README.rst
+++ b/README.rst
@@ -163,25 +163,25 @@ makes sure that:
 * the user asking for review belongs to a group ``editors`` and
   the one approving the review belongs to ``reviewers``.
 
-+----------------------------------+---------------+--------------------------------------------------------------------------+
-| Setting name                     | Default       | What does it do?                                                         |
-+==================================+===============+==========================================================================+
-| kinto.signer.to_review_enabled   | ``false``     | If ``true``, the collection ``status`` must be set to ``to-review`` by a |
-|                                  |               | different user before being set to ``to-sign``.                          |
-+----------------------------------+---------------+--------------------------------------------------------------------------+
-| kinto.signer.group_check_enabled | ``false``     | If ``true``, the user setting to ``to-review`` must belong to the        |
-|                                  |               | ``editors`` group in the source bucket, and the one setting to           |
-|                                  |               | ``to-sign`` must belong to ``reviewers``.                                |
-+----------------------------------+---------------+--------------------------------------------------------------------------+
-| kinto.signer.editors_group       | ``editors``   | The group id that is required for changing status to ``to-review``       |
-+----------------------------------+---------------+--------------------------------------------------------------------------+
-| kinto.signer.reviewers_group     | ``reviewers`` | The group id that is required for changing status to ``to-sign``         |
-+----------------------------------+---------------+--------------------------------------------------------------------------+
++----------------------------------+-------------------------------------------------+--------------------------------------------------------------------------+
+| Setting name                     | Default                                         | What does it do?                                                         |
++==================================+=================================================+==========================================================================+
+| kinto.signer.to_review_enabled   | ``false``                                       | If ``true``, the collection ``status`` must be set to ``to-review`` by a |
+|                                  |                                                 | different user before being set to ``to-sign``.                          |
++----------------------------------+-------------------------------------------------+--------------------------------------------------------------------------+
+| kinto.signer.group_check_enabled | ``false``                                       | If ``true``, the user setting to ``to-review`` must belong to the        |
+|                                  |                                                 | ``editors`` group in the source bucket, and the one setting to           |
+|                                  |                                                 | ``to-sign`` must belong to ``reviewers``.                                |
++----------------------------------+-------------------------------------------------+--------------------------------------------------------------------------+
+| kinto.signer.editors_principal   | ``group:/buckets/{bucket_id}/groups/editors```` | The principal required for changing status to ``to-review``              |
++----------------------------------+-------------------------------------------------+--------------------------------------------------------------------------+
+| kinto.signer.reviewers_principal | ``group:/buckets/{bucket_id}/groups/reviewers`` | The principal required for changing status to ``to-sign``                |
++----------------------------------+-------------------------------------------------+--------------------------------------------------------------------------+
 
 .. warning::
 
-    The ``editors`` and ``reviewers`` groups are defined in the **source bucket**
-    (e.g. ``/buckets/staging/groups/editors``).
+    The ``editors`` and ``reviewers`` principals can have placeholders that are resolved with the source **source bucket/collection**
+    (e.g. ``group:/buckets/{bucket_id}/groups/{collection_id}-reviewers``).
 
 See `Kinto groups API <http://kinto.readthedocs.io/en/stable/api/1.x/groups.html>`_ for more details about how to define groups.
 
@@ -194,7 +194,7 @@ For example:
     kinto.signer.staging.to_review_enabled = true
     kinto.signer.staging_certificates.group_check_enabled = false
     kinto.signer.staging_certificates.to_review_enabled = false
-    kinto.signer.staging_certificates.reviewers_group = certificates-reviewers
+    kinto.signer.staging_certificates.reviewers_principal = certificates-reviewers
 
 If the review process is enabled, it is possible to configure a *preview*
 collection, that will be updated and signed when the status is set to ``to-review``.

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -74,17 +74,11 @@ def includeme(config):
         config.registry.signers[key] = backend
 
         # Load the setttings associated to each resource.
-        bucket_wide = "{source[bucket]}".format(**resource)
-        collection_wide = "{source[bucket]}_{source[collection]}".format(**resource)
         for setting in ("reviewers_principal", "editors_principal",
                         "to_review_enabled", "group_check_enabled"):
-            value = settings.get("signer.%s.%s" % (collection_wide, setting))
+            value = utils.get_first_matching_setting(setting, settings, prefixes)
             if value is None:
-                # By bucket.
-                value = settings.get("signer.%s.%s" % (bucket_wide, setting))
-                if value is None:
-                    # Globally.
-                    value = settings.get("signer.%s" % setting, defaults[setting])
+                value = defaults[setting]
             # Resolve placeholder with source info.
             if setting.endswith("_principal"):
                 value = value.format(bucket_id=resource['source']['bucket'],

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -77,8 +77,7 @@ def includeme(config):
         for setting in ("reviewers_group", "editors_group",
                         "to_review_enabled", "group_check_enabled"):
             # Legacy format with _ separation between prefix and setting name.
-            value = settings.get("signer.%s.%s" % (collection_wide, setting),
-                                 settings.get("signer.%s_%s" % (collection_wide, setting)))
+            value = settings.get("signer.%s.%s" % (collection_wide, setting))
             if value is None:
                 # By bucket or globally.
                 value = settings.get("signer.%s.%s" % (bucket_wide, setting))

--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -124,8 +124,7 @@ def send_signer_events(event):
         event.request.registry.notify(review_event)
 
 
-def check_collection_status(event, resources, group_check_enabled,
-                            to_review_enabled, editors_group, reviewers_group):
+def check_collection_status(event, resources):
     """Make sure status changes are allowed.
     """
     payload = event.payload
@@ -151,17 +150,10 @@ def check_collection_status(event, resources, group_check_enabled,
         if resource is None:
             continue
 
-        _to_review_enabled = resource.get("to_review_enabled", to_review_enabled)
-        _group_check_enabled = resource.get("group_check_enabled", group_check_enabled)
-
-        _editors_group = resource.get("editors_group", editors_group)
-        editors_group_uri = instance_uri(event.request, "group",
-                                         bucket_id=payload["bucket_id"],
-                                         id=_editors_group)
-        _reviewers_group = resource.get("reviewers_group", reviewers_group)
-        reviewers_group_uri = instance_uri(event.request, "group",
-                                           bucket_id=payload["bucket_id"],
-                                           id=_reviewers_group)
+        to_review_enabled = resource["to_review_enabled"]
+        group_check_enabled = resource["group_check_enabled"]
+        editors_principal = resource["editors_principal"]
+        reviewers_principal = resource["reviewers_principal"]
 
         if old_status == new_status:
             continue
@@ -172,23 +164,23 @@ def check_collection_status(event, resources, group_check_enabled,
 
         # 2. work-in-progress -> to-review
         elif new_status == STATUS.TO_REVIEW:
-            if editors_group_uri not in user_principals and _group_check_enabled:
-                raise_forbidden(message="Not in %s group" % _editors_group)
+            if editors_principal not in user_principals and group_check_enabled:
+                raise_forbidden(message="User is not %s" % editors_principal)
 
         # 3. to-review -> work-in-progress
         # 3. to-review -> to-sign
         elif new_status == STATUS.TO_SIGN:
             # Only allow to-sign from to-review if reviewer and no-editor
-            if reviewers_group_uri not in user_principals and _group_check_enabled:
-                raise_forbidden(message="Not in %s group" % _reviewers_group)
+            if reviewers_principal not in user_principals and group_check_enabled:
+                raise_forbidden(message="User is not %s" % reviewers_principal)
 
             requires_review = old_status not in (STATUS.TO_REVIEW,
                                                  STATUS.SIGNED)
-            if requires_review and _to_review_enabled:
+            if requires_review and to_review_enabled:
                 raise_invalid(message="Collection not reviewed")
 
             is_same_editor = old_collection.get(FIELD_LAST_EDITOR) == current_user_id
-            if _to_review_enabled and is_same_editor and old_status != STATUS.SIGNED:
+            if to_review_enabled and is_same_editor and old_status != STATUS.SIGNED:
                 raise_forbidden(message="Editor cannot review")
 
         # 4. to-sign -> signed

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -23,7 +23,7 @@ def collection_timestamp(client, **kwargs):
     return headers.get('ETag', '').strip('"')
 
 
-def user_principal(client):
+def user_id(client):
     return client.server_info()['user']['id']
 
 
@@ -96,9 +96,9 @@ class BaseTestFunctional(object):
         self.source.create_bucket()
         perms = {"write": ["system.Authenticated"]}
         self.source.create_collection(permissions=perms)
-        principals = [user_principal(self.editor_client),
-                      user_principal(self.someone_client),
-                      user_principal(self.source)]
+        principals = [user_id(self.editor_client),
+                      user_id(self.someone_client),
+                      user_id(self.source)]
         create_group(self.source, "editors", members=principals)
         create_group(self.source, "reviewers", members=principals)
 
@@ -290,8 +290,8 @@ class HistoryTest(unittest.TestCase):
     def setUp(self):
         # Give the permission to write in collection to anybody
         self.source.create_bucket()
-        principals = [user_principal(self.editor_client),
-                      user_principal(self.source)]
+        principals = [user_id(self.editor_client),
+                      user_id(self.source)]
         create_group(self.source, "editors", members=principals)
         create_group(self.source, "reviewers", members=principals)
 
@@ -351,9 +351,9 @@ class WorkflowTest(unittest.TestCase):
         cls.client = Client(auth=DEFAULT_AUTH, **client_kw)
         cls.elsa_client = Client(auth=('elsa', ''), **client_kw)
         cls.anna_client = Client(auth=('anna', ''), **client_kw)
-        cls.client_principal = user_principal(cls.client)
-        cls.elsa_principal = user_principal(cls.elsa_client)
-        cls.anna_principal = user_principal(cls.anna_client)
+        cls.client_principal = user_id(cls.client)
+        cls.elsa_principal = user_id(cls.elsa_client)
+        cls.anna_principal = user_id(cls.anna_client)
 
         private_key = os.path.join(__HERE__, 'config/ecdsa.private.pem')
         cls.signer = local_ecdsa.ECDSASigner(private_key=private_key)

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -115,8 +115,9 @@ class BaseTestFunctional(object):
 
     def test_groups_and_reviewers_are_forced(self):
         capability = self.source.server_info()['capabilities']['signer']
-        assert capability['group_check_enabled']
-        assert capability['to_review_enabled']
+        for resource in capability['resources']:
+            assert resource['group_check_enabled']
+            assert resource['to_review_enabled']
 
     def test_heartbeat_is_successful(self):
         hb_url = urljoin(self.server_url, '/__heartbeat__')

--- a/tests/test_signoff_flow.py
+++ b/tests/test_signoff_flow.py
@@ -349,7 +349,7 @@ class UserGroupsTest(PostgresWebTest, FormattedErrorMixin, unittest.TestCase):
                                   code=403,
                                   errno=ERRORS.FORBIDDEN,
                                   error="Forbidden",
-                                  message="Not in editors group")
+                                  message="User is not /buckets/alice/groups/editors")
 
         self.app.patch_json(self.source_collection,
                             {"data": {"status": "to-review"}},
@@ -368,7 +368,7 @@ class UserGroupsTest(PostgresWebTest, FormattedErrorMixin, unittest.TestCase):
                                   code=403,
                                   errno=ERRORS.FORBIDDEN,
                                   error="Forbidden",
-                                  message="Not in reviewers group")
+                                  message="User is not /buckets/alice/groups/reviewers")
 
         self.app.patch_json(self.source_collection,
                             {"data": {"status": "to-sign"}},
@@ -391,8 +391,8 @@ class SpecificUserGroupsTest(PostgresWebTest, FormattedErrorMixin, unittest.Test
 
         settings['signer.group_check_enabled'] = 'false'
         settings['signer.alice_cid1.group_check_enabled'] = 'true'
-        settings['signer.alice_cid1.editors_group'] = 'editeurs'
-        settings['signer.alice_cid1.reviewers_group'] = 'revoyeurs'
+        settings['signer.alice_cid1.editors_principal'] = '/buckets/alice/groups/editeurs'
+        settings['signer.alice_cid1.reviewers_principal'] = '/buckets/alice/groups/revoyeurs'
         return settings
 
     def setUp(self):
@@ -426,7 +426,7 @@ class SpecificUserGroupsTest(PostgresWebTest, FormattedErrorMixin, unittest.Test
                                   code=403,
                                   errno=ERRORS.FORBIDDEN,
                                   error="Forbidden",
-                                  message="Not in editeurs group")
+                                  message="User is not /buckets/alice/groups/editeurs")
 
     def test_only_reviewers_can_ask_to_sign(self):
         self.app.patch_json(self.source_collection1,
@@ -440,7 +440,7 @@ class SpecificUserGroupsTest(PostgresWebTest, FormattedErrorMixin, unittest.Test
                                   code=403,
                                   errno=ERRORS.FORBIDDEN,
                                   error="Forbidden",
-                                  message="Not in revoyeurs group")
+                                  message="User is not /buckets/alice/groups/revoyeurs")
 
 
 class PreviewCollectionTest(PostgresWebTest, unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     flake8
 
 [testenv:functional]
-basepython = python3.5
+basepython = python3.6
 deps =
     -rdev-requirements.txt
 commands =


### PR DESCRIPTION
Fixes #205

Based on #208 

* [x] Change settings
* [x] Break everything in capabilities
* [ ] Add principals check in Kinto-Admin (using principals in hello endpoint and principal mentioned in capabilities) instead of group check 
* [ ] Find out the best way to smoothen the migration path
* [ ] Update changelog