### PR TITLE
Allow placeholders in review settings (fixes #210)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ This document describes changes between each past release.
 
 - Allow configuration of ``reviewers_group``, ``editors_group``, ``to_review_enabled``, ``group_check_enabled``
   by bucket
+- Allow placeholders ``{bucket_id}`` and ``{collection_id}`` in ``reviewers_group``, ``editors_group``,
+  ``to_review_enabled``, and ``group_check_enabled`` settings
+  (e.g. ``group:/buckets/{bucket_id}/groups/{collection_id}-reviewers``) (fixes #210)
 
 
 2.2.0 (2017-12-06)

--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,10 @@ makes sure that:
     The ``editors`` and ``reviewers`` groups are defined in the **source bucket**
     (e.g. ``/buckets/staging/groups/editors``).
 
+    The ``editors`` and ``reviewers`` groups can have placeholders that are resolved
+    with the source **source bucket/collection**
+    (e.g. ``group:/buckets/{bucket_id}/groups/{collection_id}-reviewers``).
+
 See `Kinto groups API <http://kinto.readthedocs.io/en/stable/api/1.x/groups.html>`_ for more details about how to define groups.
 
 The above settings can be set or overriden by bucket using the ``<bucket_id>_`` prefix or by collection using the ``<bucket_id>_<collection_id>_`` prefix.

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -22,6 +22,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
+        settings['signer.reviewers_group'] = '{bucket_id}-{collection_id}-reviewers'
         settings['signer.alice.reviewers_group'] = 'revoyeurs'
         settings['signer.alice_source.to_review_enabled'] = 'true'
         return settings
@@ -38,7 +39,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
             "to_review_enabled": False,
             "group_check_enabled": False,
             "editors_group": "editors",
-            "reviewers_group": "reviewers",
+            "reviewers_group": "{bucket_id}-{collection_id}-reviewers",
             "resources": [{
                 "destination": {"bucket": "alice",
                                 "collection": "destination"},
@@ -58,7 +59,8 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
                 "destination": {"bucket": "bob",
                                 "collection": "destination"},
                 "source": {"bucket": "bob",
-                           "collection": "source"}
+                           "collection": "source"},
+                "reviewers_group": "bob-source-reviewers",
             }]
         }
         self.assertEqual(expected, capabilities['signer'])


### PR DESCRIPTION
Fixes #210

Based on #208 

> Note: this is backward compatible with Kinto-Admin since we expand the placeholders for every collection in the capabilities