### PR TITLE
Fix overriding of per-bucket settings (Ref #215)

### DIFF
--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -74,8 +74,7 @@ def includeme(config):
         config.registry.signers[key] = backend
 
         # Load the setttings associated to each resource.
-        for setting in ("reviewers_group", "editors_group",
-                        "to_review_enabled", "group_check_enabled"):
+        for setting in listeners.REVIEW_SETTINGS:
             default = defaults[setting]
             # Global to all collections.
             global_settings[setting] = settings.get("signer.%s" % setting, default)

--- a/tests/test_signoff_flow.py
+++ b/tests/test_signoff_flow.py
@@ -506,6 +506,10 @@ class PerBucketTest(PostgresWebTest, unittest.TestCase):
             cls.source_bucket,
             cls.preview_bucket,
             cls.destination_bucket])
+
+        settings['signer.to_review_enabled'] = 'true'
+        settings['signer.stage_specific.to_review_enabled'] = 'false'
+
         return settings
 
     def test_destination_does_not_exist_at_first(self):
@@ -520,5 +524,11 @@ class PerBucketTest(PostgresWebTest, unittest.TestCase):
 
         self.app.patch_json(self.source_collection,
                             {"data": {"status": "to-sign"}},
-                            headers=self.headers)
+                            headers=self.other_headers)
         self.app.get(self.destination_collection, headers=self.headers, status=200)
+
+    def test_review_settings_can_be_overriden_for_a_specific_collection(self):
+        # review is not enabled for this particular one, sign directly!
+        self.app.put_json(self.source_bucket + "/collections/specific",
+                          {"data": {"status": "to-sign"}},
+                          headers=self.headers)


### PR DESCRIPTION
Ref #215 

Discovered while hacking on #218: if a setting was overriden for a specific collection with the rest configured as per-bucket, it was **not** taken into account.

I'm not super happy about the fix (going back to settings in `pick_resource_and_signer()`), but I can't see any better way with the current code. See #220