### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Here is an example of what a configuration could look like:
   kinto.includes = kinto_signer
 
   kinto.signer.resources =
-      /buckets/source                         -> /bucket/destination
+      /buckets/source                         -> /buckets/destination
       /buckets/source/collections/collection1 -> /buckets/destination/collections/collection2
       /buckets/bid/collections/cid            -> /buckets/bid/collections/cid2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ cornice-swagger==0.5.2
 dockerflow==2017.11.0
 docutils==0.14
 ecdsa==0.13
-enum34==1.1.6
 hupper==1.0
 idna==2.6
 iso8601==0.1.12

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,10 @@ setup(name='kinto-signer',
       license='Apache License (2.0)',
       classifiers=[
           "Programming Language :: Python",
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: Implementation :: CPython',
           "Topic :: Internet :: WWW/HTTP",
           "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
           "License :: OSI Approved :: Apache Software License"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ REQUIREMENTS = [
     'kinto>=7.1.0',
     'boto3',
     'ecdsa',
-    'enum34',
     'requests-hawk',
 ]
 


### PR DESCRIPTION
This let me run kinto-signer successfully in a Python 3.6 venv.