### PR TITLE
Give write permission to reviewers/editors groups on newly created collections (fixes #237)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,13 @@ This document describes changes between each past release.
 3.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
+
+- Give write permission to reviewers/editors groups on newly created collections (fixes #237)
+
+**Internal changes**
+
+- Now log an INFO message when the CloudFront invalidation request is sent (fixes #238)
 
 
 3.1.0 (2018-03-16)

--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -357,3 +357,14 @@ def create_editors_reviewers_groups(event, resources, editors_group, reviewers_g
                                        record={'id': group, 'members': members},
                                        permissions=group_perms,
                                        matchdict={'bucket_id': bid, 'id': group})
+
+        # Allow those groups to write to the source collection.
+        permission = event.request.registry.permission
+        collection_uri = instance_uri(event.request, "collection",
+                                      bucket_id=bid,
+                                      id=resource["source"]["collection"])
+        for group in (_editors_group, _reviewers_group):
+            group_principal = instance_uri(event.request, "group",
+                                           bucket_id=bid,
+                                           id=group)
+            permission.add_principal_to_ace(collection_uri, 'write', group_principal)


### PR DESCRIPTION
Fixes #237 