### PR TITLE
Rename and change date tracking fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 3.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Tracking fields with dates were renamed and changed to timestamps (``last_edit_at``, ``last_request_review_at``, ``last_review_at`` and ``last_signature_at``)
 
 
 3.2.0 (2018-04-11)

--- a/README.rst
+++ b/README.rst
@@ -359,13 +359,13 @@ Tracking fields
 During the review process, the *source* collection metadata will receive the following read-only fields:
 
 - ``last_edit_by``: last user to perform change on records in the source collection
-- ``last_edit_date``: date of the last records change
+- ``last_edit_at``: timestamp of the last records change
 - ``last_review_request_by``: last user to request a review
-- ``last_review_request_date``: date of the last review request
+- ``last_review_request_at``: timestamp of the last review request
 - ``last_review_by``: last user to approve a review
-- ``last_review_date``: date of the last review approval
+- ``last_review_at``: timestamp of the last review approval
 - ``last_signature_by``: last user to trigger a signature
-- ``last_signature_date``: date of the last signature
+- ``last_signature_at``: timestamp of the last signature
 
 .. note:
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -95,13 +95,13 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
         # We created two records, for each of them we updated the ``last_edit_datr``
         # field, so we received two events.
         self.assertIsNone(events[0].impacted_records[0]["old"].get("status"))
-        self.assertIsNone(events[0].impacted_records[0]["old"].get("last_edit_date"))
+        self.assertIsNone(events[0].impacted_records[0]["old"].get("last_edit_at"))
         self.assertEqual(events[0].payload["user_id"], "plugin:kinto-signer")
         self.assertEqual(events[0].impacted_records[0]["new"]["status"],
                          "work-in-progress")
         self.assertIn("basicauth:", events[0].impacted_records[0]["new"]["last_edit_by"])
-        self.assertNotEqual(events[0].impacted_records[0]["new"]["last_edit_date"],
-                            events[-1].impacted_records[0]["new"]["last_edit_date"])
+        self.assertNotEqual(events[0].impacted_records[0]["new"]["last_edit_at"],
+                            events[-1].impacted_records[0]["new"]["last_edit_at"])
 
     def test_resource_changed_is_triggered_for_to_review(self):
         before = len(listener.received)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -188,8 +188,8 @@ class LocalUpdaterTest(unittest.TestCase):
         self.storage.get.return_value = {'id': 1234, 'last_modified': 1234,
                                          'status': 'to-sign'}
 
-        with mock.patch("kinto_signer.updater.datetime") as mocked:
-            mocked.datetime.now().isoformat.return_value = "2018-04-09"
+        with mock.patch("kinto_signer.updater.msec_time") as mocked:
+            mocked.return_value = 12345
             self.updater.update_source_status(STATUS.SIGNED, DummyRequest())
 
         self.storage.update.assert_called_with(
@@ -199,9 +199,9 @@ class LocalUpdaterTest(unittest.TestCase):
             record={
                 'id': 1234,
                 'last_review_by': 'basicauth:bob',
-                'last_review_date': '2018-04-09',
+                'last_review_at': 12345,
                 'last_signature_by': 'basicauth:bob',
-                'last_signature_date': '2018-04-09',
+                'last_signature_at': 12345,
                 'status': "signed"
             })
 


### PR DESCRIPTION
Again, I'm not super convinced about the naming (eg. `last_modified` versus `last_edit_at`) but I believe it's good enough. Please share your ideas if you feel like to ;)