### PR TITLE
Make sure the dates in tracking fields are given on the UTC timezone

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 3.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Make sure the dates in tracking fields are given on the UTC timezone
 
 
 3.2.0 (2018-04-11)

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -300,14 +300,14 @@ class LocalUpdater(object):
             old=collection_record)
 
     def update_source_review_request_by(self, request):
-        current_date = datetime.datetime.now().isoformat()
+        current_date = datetime.datetime.now(datetime.timezone.utc).isoformat()
         attrs = {TRACKING_FIELDS.LAST_REVIEW_REQUEST_BY.value: request.prefixed_userid,
                  TRACKING_FIELDS.LAST_REVIEW_REQUEST_DATE.value: current_date}
         return self._update_source_attributes(request, **attrs)
 
     def update_source_status(self, status, request, old_status=None):
         current_userid = request.prefixed_userid
-        current_date = datetime.datetime.now().isoformat()
+        current_date = datetime.datetime.now(datetime.timezone.utc).isoformat()
         attrs = {'status': status.value}
         if status == STATUS.WORK_IN_PROGRESS:
             attrs[TRACKING_FIELDS.LAST_EDIT_BY.value] = current_userid


### PR DESCRIPTION
As recommended by @glasserc  in #244 

```
>>> Date.parse('2018-04-25T11:22:43.967335')
1524648163967

>>> Date.parse('2018-04-25T11:22:43.967335+00:00')
1524655363967
```