### PR TITLE
Cleanup preview and destination when source collection is deleted (fixes #114)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 3.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Cleanup preview and destination when source collection is deleted (fixes #114)
 
 
 3.2.1 (2018-04-25)

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -150,6 +150,13 @@ def includeme(config):
         for_actions=(ACTIONS.CREATE,),
         for_resources=('collection',))
 
+    config.add_subscriber(
+        functools.partial(listeners.cleanup_preview_destination,
+                          resources=resources),
+        ResourceChanged,
+        for_actions=(ACTIONS.DELETE,),
+        for_resources=('collection',))
+
     sign_data_listener = functools.partial(listeners.sign_collection_data,
                                            resources=resources)
 

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -385,6 +385,11 @@ class SourceCollectionDeletion(BaseWebTest, unittest.TestCase):
         self.app.patch_json("/buckets/stage/collections/a", {"data": {"status": "to-sign"}},
                             headers=self.headers)
 
+    def test_unsigned_collection_are_not_affected(self):
+        self.app.put_json("/buckets/bid", headers=self.headers)
+        self.app.put_json("/buckets/bid/collections/a", headers=self.headers)
+        self.app.delete("/buckets/bid/collections/a", headers=self.headers)
+
     def test_destination_content_is_deleted_when_source_is_deleted(self):
         # Destination is empty.
         resp = self.app.get("/buckets/prod/collections/a/records", headers=self.headers)

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -348,9 +348,9 @@ class SourceCollectionDeletion(BaseWebTest, unittest.TestCase):
 
         # Patch calls to Autograph.
         patch = mock.patch('kinto_signer.signer.autograph.requests')
-        self.mock = patch.start()
+        mocked = patch.start()
         self.addCleanup(patch.stop)
-        self.mock.post.return_value.json.side_effect = lambda: [{
+        mocked.post.return_value.json.side_effect = lambda: [{
             "signature": uuid.uuid4().hex.encode("utf-8"),
             "hash_algorithm": "",
             "signature_encoding": "",
@@ -388,7 +388,14 @@ class SourceCollectionDeletion(BaseWebTest, unittest.TestCase):
     def test_unsigned_collection_are_not_affected(self):
         self.app.put_json("/buckets/bid", headers=self.headers)
         self.app.put_json("/buckets/bid/collections/a", headers=self.headers)
+
+        patch = mock.patch('kinto_signer.updater.LocalUpdater.sign_and_update_destination')
+        mocked = patch.start()
+        self.addCleanup(patch.stop)
+
         self.app.delete("/buckets/bid/collections/a", headers=self.headers)
+
+        assert not mocked.called
 
     def test_destination_content_is_deleted_when_source_is_deleted(self):
         # Destination is empty.

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -1,4 +1,5 @@
 import unittest
+import uuid
 
 import mock
 import pytest
@@ -344,6 +345,18 @@ class SourceCollectionDeletion(BaseWebTest, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
+
+        # Patch calls to Autograph.
+        patch = mock.patch('kinto_signer.signer.autograph.requests')
+        self.mock = patch.start()
+        self.addCleanup(patch.stop)
+        self.mock.post.return_value.json.side_effect = lambda: [{
+            "signature": uuid.uuid4().hex.encode("utf-8"),
+            "hash_algorithm": "",
+            "signature_encoding": "",
+            "content-signature": "",
+            "x5u": ""}]
+
         self.headers = get_user_headers('me')
 
         self.other_headers = get_user_headers('Sam:Wan Heilss')


### PR DESCRIPTION
Fixes #114 

I realized that QA would need to create / delete / and potentially recreate source collections.

Instead of deleting the preview/destination collections, which would break clients, I delete the records with tombstones and resign as empty.