### PR TITLE
Move from pytest-cover to pytest-cov

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ pytest
 mock
 pytest-watch
 pytest-cache
-pytest-cover
+pytest-cov
 pytest-sugar
 statsd
 tox


### PR DESCRIPTION
pytest-cover was deprecated some time ago.

See also https://github.com/Kinto/kinto/pull/1543.