### PR TITLE
Update now that events can trigger events

### DIFF
--- a/kinto_signer/utils.py
+++ b/kinto_signer/utils.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from contextlib import contextmanager
 
 from kinto.views import NameGenerator
 from kinto.core.events import ACTIONS
@@ -195,18 +194,3 @@ def notify_resource_event(request, request_options, matchdict,
                                       data=record,
                                       action=action,
                                       old=old)
-
-
-@contextmanager
-def send_resource_events(request):
-    # Backup resource events generated until now and set it to empty dict.
-    before_events = request.bound_data["resource_events"]
-    request.bound_data["resource_events"] = OrderedDict()
-    yield
-    # The resource events we gathered during listeners and hooks of kinto-signer
-    # can now be added to ``kinto_signer.events`` which will be sent later
-    # in ``listeners.send_signer_events()``.
-    new_events = request.get_resource_events()
-    request.bound_data.setdefault('kinto_signer.events', []).extend(new_events)
-    # Restore backup.
-    request.bound_data["resource_events"] = before_events

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ jmespath==0.9.3
 jsonpatch==1.21
 jsonpointer==2.0
 jsonschema==2.6.0
-kinto==8.2.0
+kinto==10.0.0
 logging-color-formatter==1.0.2
 mohawk==0.3.4
 PasteDeploy==1.5.2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     README = f.read()
 
 REQUIREMENTS = [
-    'kinto>=7.1.0',
+    'kinto>=10.0.0',
     'boto3',
     'ecdsa',
     'requests-hawk',


### PR DESCRIPTION
It seems that this entire send_resource_events function only exists as
a workaround for the problem that is being fixed by
Kinto/kinto#1671.

This PR won't work until Kinto/kinto#1671 lands and is released, but (assuming the tests pass), does this seem OK to you, @leplatrem ?

Fixes #263. Note that we leave the explicit manipulation of `kinto_signer.events` in place -- this is meant to let us trigger events after resource events but before the transaction commits.