### PR TITLE
Rewrite e2e to use .get_records_timestamp() (#258)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 3.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Rewrite e2e to use ``.get_records_timestamp()`` (#258)
 
 
 3.3.3 (2018-10-10)

--- a/scripts/e2e.py
+++ b/scripts/e2e.py
@@ -18,13 +18,6 @@ def _rand(size=10):
     return ''.join([random.choice(hexdigits) for _ in range(size)])
 
 
-def collection_timestamp(client):
-    # XXXX Waiting https://github.com/Kinto/kinto-http.py/issues/77
-    endpoint = client.get_endpoint('records')
-    record_resp, headers = client.session.request('get', endpoint)
-    return headers.get('ETag', '').strip('"')
-
-
 def upload_records(client, num):
     records = []
     for i in range(num):
@@ -156,7 +149,7 @@ def main():
         metadata = preview_client.get_collection()['data']
         preview_signature = metadata.get('signature')
         assert preview_signature, 'Preview collection not signed'
-        preview_timestamp = collection_timestamp(preview_client)
+        preview_timestamp = preview_client.get_records_timestamp()
     # 2.3 approve the review
     print('Reviewer approves and triggers signature')
     data = {"status": "to-sign"}
@@ -205,7 +198,7 @@ def main():
 
     records = list(dest_client.get_records())
     assert len(records) == expected, '%s != %s records' % (len(records), expected)
-    timestamp = collection_timestamp(dest_client)
+    timestamp = dest_client.get_records_timestamp()
     serialized = canonical_json(records, timestamp)
     print('Hash is %r' % compute_hash(serialized))
 


### PR DESCRIPTION
Fixes #258