### PR TITLE
Fix copy of deleted records (ref #283)

### DIFF
--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -411,6 +411,12 @@ def cleanup_preview_destination(event, resources):
                                    permission=event.request.registry.permission,
                                    source=resource['source'],
                                    destination=resource[k])
+
+            # At this point, the DELETE event was sent for the source collection,
+            # but the source records may not have been deleted yet (it happens in an event
+            # listener too). That's why we don't copy the records otherwise it will
+            # recreate the records that were just deleted.
             updater.sign_and_update_destination(event.request,
                                                 source_attributes=old_collection,
-                                                next_source_status=None)
+                                                next_source_status=None,
+                                                push_records=False)

--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -89,9 +89,9 @@ def sign_collection_data(event, resources, to_review_enabled, **kwargs):
         return
 
     # Prevent recursivity, since the following operations will alter the current collection.
-    impacted_records = list(event.impacted_records)
+    impacted_objects = list(event.impacted_objects)
 
-    for impacted in impacted_records:
+    for impacted in impacted_objects:
         new_collection = impacted['new']
         old_collection = impacted.get('old', {})
 
@@ -217,7 +217,7 @@ def check_collection_status(event, resources, group_check_enabled,
 
     user_principals = event.request.effective_principals
 
-    for impacted in event.impacted_records:
+    for impacted in event.impacted_objects:
         old_collection = impacted.get("old", {})
         old_status = old_collection.get("status")
         new_collection = impacted["new"]
@@ -299,7 +299,7 @@ def check_collection_tracking(event, resources):
     if event.request.prefixed_userid == PLUGIN_USERID:
         return
 
-    for impacted in event.impacted_records:
+    for impacted in event.impacted_objects:
         old_collection = impacted.get("old", {})
         new_collection = impacted["new"]
 
@@ -347,7 +347,7 @@ def create_editors_reviewers_groups(event, resources, editors_group, reviewers_g
 
     authz = event.request.registry.getUtility(IAuthorizationPolicy)
 
-    for impacted in event.impacted_records:
+    for impacted in event.impacted_objects:
         new_collection = impacted["new"]
 
         # Skip if collection is not configured for review.

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -177,7 +177,7 @@ class LocalUpdater(object):
                                 'id': collection_name
                                })
 
-    def _get_records(self, rc, last_modified=None, empty_none=True):
+    def _get_records(self, resource, last_modified=None, empty_none=True):
         # If last_modified was specified, only retrieve items since then.
         storage_kwargs = {}
         if last_modified is not None:
@@ -186,14 +186,15 @@ class LocalUpdater(object):
             storage_kwargs['filters'] = [gt_last_modified, ]
 
         storage_kwargs['sorting'] = [Sort(FIELD_LAST_MODIFIED, 1)]
-        parent_id = "/buckets/{bucket}/collections/{collection}".format(**rc)
+        parent_id = "/buckets/{bucket}/collections/{collection}".format(**resource)
 
         records = self.storage.list_all(parent_id=parent_id,
                                         resource_name='record',
                                         include_deleted=True,
                                         **storage_kwargs)
+        count_all = self.storage.count_all(parent_id=parent_id, resource_name='record')
 
-        if len(records) == 0 and empty_none:
+        if count_all == 0 and empty_none:
             # When the collection empty (no records and no tombstones)
             collection_timestamp = None
         else:

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -104,7 +104,8 @@ class LocalUpdater(object):
 
     def sign_and_update_destination(self, request, source_attributes,
                                     next_source_status=STATUS.SIGNED,
-                                    previous_source_status=None):
+                                    previous_source_status=None,
+                                    push_records=True):
         """Sign the specified collection.
 
         0. Create the destination bucket / collection
@@ -116,7 +117,8 @@ class LocalUpdater(object):
         """
         self.create_destination(request)
 
-        self.push_records_to_destination(request)
+        if push_records:
+            self.push_records_to_destination(request)
 
         records, timestamp = self.get_destination_records(empty_none=False)
         serialized_records = canonical_json(records, timestamp)

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -194,9 +194,8 @@ class LocalUpdater(object):
                                         resource_name='record',
                                         include_deleted=True,
                                         **storage_kwargs)
-        count_all = self.storage.count_all(parent_id=parent_id, resource_name='record')
 
-        if count_all == 0 and empty_none:
+        if len(records) == 0 and empty_none:
             # When the collection empty (no records and no tombstones)
             collection_timestamp = None
         else:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     README = f.read()
 
 REQUIREMENTS = [
-    'kinto>=12.0.0',
+    'kinto>=12.0.1',
     'boto3',
     'ecdsa',
     'requests-hawk',

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -242,7 +242,7 @@ class SignoffEventsTest(BaseWebTest, unittest.TestCase):
         config = Configurator(settings=cls.get_app_settings())
 
         def on_review_received(event):
-            event.request.registry.storage.create(collection_id='custom',
+            event.request.registry.storage.create(resource_name='custom',
                                                   parent_id='',
                                                   record={'pi': 3.14})
 
@@ -351,5 +351,5 @@ class SignoffEventsTest(BaseWebTest, unittest.TestCase):
         assert len(self.events) == 0
 
     def test_database_changes_in_subscribers_are_committed(self):
-        count = self.storage.count_all(collection_id='custom', parent_id='')
+        count = self.storage.count_all(resource_name='custom', parent_id='')
         assert count == 1

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -351,5 +351,5 @@ class SignoffEventsTest(BaseWebTest, unittest.TestCase):
         assert len(self.events) == 0
 
     def test_database_changes_in_subscribers_are_committed(self):
-        _, count = self.storage.get_all(collection_id='custom', parent_id='')
+        count = self.storage.count_all(collection_id='custom', parent_id='')
         assert count == 1

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -249,7 +249,7 @@ class OnCollectionChangedTest(unittest.TestCase):
 
     def test_nothing_happens_when_status_is_not_to_sign(self):
         evt = mock.MagicMock(payload={"action": "update", "bucket_id": "a", "collection_id": "b"},
-                             impacted_records=[{
+                             impacted_objects=[{
                                  "new": {"id": "b", "status": "signed"}}])
         sign_collection_data(evt, resources=utils.parse_resources("a/b -> c/d"),
                              to_review_enabled=True)
@@ -257,7 +257,7 @@ class OnCollectionChangedTest(unittest.TestCase):
 
     def test_updater_is_called_when_resource_and_status_matches(self):
         evt = mock.MagicMock(payload={"action": "update", "bucket_id": "a", "collection_id": "b"},
-                             impacted_records=[{
+                             impacted_objects=[{
                                  "new": {"id": "b", "status": "to-sign"}}])
         evt.request.registry.storage = mock.sentinel.storage
         evt.request.registry.permission = mock.sentinel.permission
@@ -279,7 +279,7 @@ class OnCollectionChangedTest(unittest.TestCase):
 
     def test_kinto_attachment_property_is_set_to_allow_metadata_updates(self):
         evt = mock.MagicMock(payload={"action": "update", "bucket_id": "a", "collection_id": "b"},
-                             impacted_records=[{
+                             impacted_objects=[{
                                  "new": {"id": "b", "status": "to-sign"}}])
         evt.request.registry.storage = mock.sentinel.storage
         evt.request.registry.permission = mock.sentinel.permission

--- a/tests/test_signoff_flow.py
+++ b/tests/test_signoff_flow.py
@@ -640,6 +640,42 @@ class PreviewCollectionTest(SignoffWebTest, unittest.TestCase):
         signature_preview_after = resp.json['data']['signature']
         assert signature_preview_before != signature_preview_after
 
+    def test_the_preview_collection_is_emptied_when_source_records_are_deleted(self):
+        self.app.patch_json(self.source_collection,
+                            {"data": {"status": "to-review"}},
+                            headers=self.headers)
+        self.app.patch_json(self.source_collection,
+                            {"data": {"status": "to-sign"}},
+                            headers=self.other_headers)
+
+        records = self.app.get(self.source_collection + "/records", headers=self.headers).json["data"]
+        for r in records:
+            self.app.delete(self.source_collection + "/records/" + r["id"], headers=self.headers)
+        self.app.patch_json(self.source_collection,
+                            {"data": {"status": "to-review"}},
+                            headers=self.headers)
+
+        resp = self.app.get(self.preview_collection + "/records", headers=self.headers)
+        records = resp.json["data"]
+        assert len(records) == 0
+
+    def test_the_preview_collection_is_emptied_when_source_is_deleted(self):
+        self.app.patch_json(self.source_collection,
+                            {"data": {"status": "to-review"}},
+                            headers=self.headers)
+        self.app.patch_json(self.source_collection,
+                            {"data": {"status": "to-sign"}},
+                            headers=self.other_headers)
+
+        self.app.delete(self.source_collection + "/records", headers=self.headers).json["data"]
+        self.app.patch_json(self.source_collection,
+                            {"data": {"status": "to-review"}},
+                            headers=self.headers)
+
+        resp = self.app.get(self.preview_collection + "/records", headers=self.headers)
+        records = resp.json["data"]
+        assert len(records) == 0
+
 
 class NoReviewNoPreviewTest(SignoffWebTest, unittest.TestCase):
     """

--- a/tests/test_signoff_flow.py
+++ b/tests/test_signoff_flow.py
@@ -648,7 +648,8 @@ class PreviewCollectionTest(SignoffWebTest, unittest.TestCase):
                             {"data": {"status": "to-sign"}},
                             headers=self.other_headers)
 
-        records = self.app.get(self.source_collection + "/records", headers=self.headers).json["data"]
+        resp = self.app.get(self.source_collection + "/records", headers=self.headers)
+        records = resp.json["data"]
         for r in records:
             self.app.delete(self.source_collection + "/records/" + r["id"], headers=self.headers)
         self.app.patch_json(self.source_collection,


### PR DESCRIPTION
The more I try to investigate the more I get lost with what seems to happen...

Like, I added this print after the delete in the tests:

```py

        dest_ts = int(self.app.head(self.destination_collection + "/records", headers=self.headers).headers["ETag"][1:-1])
        ts = [r["last_modified"] for r in self.app.get(self.source_collection + "/records?_since=0", headers=self.headers).json["data"]]
        print("dest col ts=", dest_ts, "source records=", ts, [t > dest_ts for t in ts])
```

And here's what I obtain:
```
dest col ts= 1547747840898 source records= [1547744241061, 1547744241039] [False, False]
```

How come the timestamps of the deleted tombstones are not superior to the destination timestamp if the delete happens after it was updated... ?

I'll leave it for a while..