### PR TITLE
kinto-signer exposes signing settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,12 @@ Changelog
 
 This document describes changes between each past release.
 
-4.1.0 (unreleased)
+4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Security issue**
+
+- Signer parameters were displayed in capabilities. Fixed in #326.
 
 
 4.0.0 (2019-01-22)

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -16,11 +16,11 @@ def get_exposed_resources(resource_dict, review_settings):
     This should include review settings for each resource but nothing
     related to the actual signing parameters for those resources."""
     out = []
-    for dict in resource_dict.values():
+    for resource in resource_dict.values():
         sanitized = {}
         for setting in ["source", "destination", "preview"] + list(review_settings):
-            if setting in dict:
-                sanitized[setting] = dict[setting]
+            if setting in resource:
+                sanitized[setting] = resource[setting]
         out.append(sanitized)
 
     return out

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -10,6 +10,22 @@ __version__ = pkg_resources.get_distribution(__package__).version
 DEFAULT_SIGNER = "kinto_signer.signer.local_ecdsa"
 
 
+def get_exposed_resources(resource_dict, review_settings):
+    """Compute a set of resources to be shown as part of the server's capabilities.
+
+    This should include review settings for each resource but nothing
+    related to the actual signing parameters for those resources."""
+    out = []
+    for dict in resource_dict.values():
+        sanitized = {}
+        for setting in ["source", "destination", "preview"] + list(review_settings):
+            if setting in dict:
+                sanitized[setting] = dict[setting]
+        out.append(sanitized)
+
+    return out
+
+
 def includeme(config):
     # We import stuff here, so that kinto-signer can be installed with `--no-deps`
     # and used without having this Pyramid ecosystem installed.
@@ -131,11 +147,12 @@ def includeme(config):
                 resource.pop(setting, None)
 
     # Expose the capabilities in the root endpoint.
+    exposed_resources = get_exposed_resources(resources, listeners.REVIEW_SETTINGS)
     message = "Digital signatures for integrity and authenticity of records."
     docs = "https://github.com/Kinto/kinto-signer#kinto-signer"
     config.add_api_capability("signer", message, docs,
                               version=__version__,
-                              resources=resources.values(),
+                              resources=exposed_resources,
                               **global_settings)
 
     config.add_subscriber(

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -153,6 +153,29 @@ class IncludeMeTest(unittest.TestCase):
         }
         self.includeme(settings)
 
+    def test_includeme_sanitizes_exposed_settings(self):
+        settings = {
+            "signer.resources": (
+                "/buckets/sb1 -> /buckets/db1\n"
+                "/buckets/sb2 -> /buckets/db2\n"
+            ),
+            "signer.signer_backend": "kinto_signer.signer.local_ecdsa",
+            "signer.ecdsa.public_key": "/path/to/key",
+            "signer.ecdsa.private_key": "/path/to/private",
+            "signer.sb1.sc1.signer_backend": "kinto_signer.signer.local_ecdsa",
+            "signer.sb1.sc1.ecdsa.public_key": "/path/to/key",
+            "signer.sb1.sc1.ecdsa.private_key": "/path/to/private",
+            "signer.sb2.signer_backend": "kinto_signer.signer.local_ecdsa",
+            "signer.sb2.ecdsa.public_key": "/path/to/key",
+            "signer.sb2.ecdsa.private_key": "/path/to/private",
+        }
+        config = self.includeme(settings)
+        all_capabilities = config.registry.api_capabilities
+        capabilities = all_capabilities["signer"]
+        for resource in capabilities["resources"]:
+            assert "ecdsa.private_key" not in resource
+            assert "private_key" not in resource
+
     def test_defines_a_signer_per_bucket_and_collection(self):
         settings = {
             "signer.resources": (


### PR DESCRIPTION
@leplatrem discovered this by accident today. It's a security bug that was introduced by #280. So far we're only affected on per-collection settings, but in fact a related bug seems to be present for per-bucket settings.