### PR TITLE
Bump timestamps when pushing in destination collection (fixes #779)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 5.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Breaking changes**
+
+- Records timestamps are now bumped when copied to preview/destination collections (fixes #779)
 
 
 5.2.1 (2019-10-03)

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -282,14 +282,14 @@ class LocalUpdater(object):
             except RecordNotFoundError:
                 before = None
 
+            # Timestamp should be bumped in destination.
+            record = {**record}
+            del record[FIELD_LAST_MODIFIED]
+
             deleted = record.get("deleted", False)
             if deleted:
                 try:
-                    pushed = self.storage.delete(
-                        object_id=record[FIELD_ID],
-                        last_modified=record[FIELD_LAST_MODIFIED],
-                        **storage_kwargs,
-                    )
+                    pushed = self.storage.delete(object_id=record[FIELD_ID], **storage_kwargs,)
                     action = ACTIONS.DELETE
                 except RecordNotFoundError:
                     # If the record doesn't exists in the destination

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -592,7 +592,8 @@ class PerBucketTest(unittest.TestCase):
 
         # Create some records.
         self.julia_client.create_record(id="abc", collection="pim")
-        self.julia_client.create_record(id="def", collection="pim")
+        record = self.julia_client.create_record(id="def", collection="pim")
+        timestamp_before_approval = record["data"]["last_modified"]
 
         # Preview and prod have no records yet.
         records = self.anon_client.get_records(bucket="preview", collection="pim")
@@ -613,6 +614,8 @@ class PerBucketTest(unittest.TestCase):
         # Prod now has records.
         records = self.anon_client.get_records(bucket="prod", collection="pim")
         assert len(records) == 2
+        # Publishing to destination bumped the timestamps.
+        assert records[0]["last_modified"] != timestamp_before_approval
 
         # Refresh signature
         self.joan_client.patch_collection(id="pim", data={"status": "to-resign"})

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -72,7 +72,9 @@ class LocalUpdaterTest(unittest.TestCase):
 
     def test_get_destination_records(self):
         # We want to test get_destination_records with some records.
-        records = [{"id": idx, "foo": "bar %s" % idx} for idx in range(1, 4)]
+        records = [
+            {"id": idx, "foo": "bar %s" % idx, "last_modified": 42 - idx} for idx in range(1, 4)
+        ]
         self.storage.list_all.return_value = records
         self.updater.get_destination_records()
         self.storage.resource_timestamp.assert_called_with(
@@ -87,7 +89,9 @@ class LocalUpdaterTest(unittest.TestCase):
 
     def test_push_records_to_destination(self):
         self.patch(self.updater, "get_destination_records", return_value=([], 1324))
-        records = [{"id": idx, "foo": "bar %s" % idx} for idx in range(1, 4)]
+        records = [
+            {"id": idx, "foo": "bar %s" % idx, "last_modified": 42 - idx} for idx in range(1, 4)
+        ]
         self.patch(self.updater, "get_source_records", return_value=(records, 1325))
         self.updater.push_records_to_destination(DummyRequest())
         assert self.storage.update.call_count == 3
@@ -106,7 +110,9 @@ class LocalUpdaterTest(unittest.TestCase):
 
     def test_push_records_removes_deleted_records(self):
         self.patch(self.updater, "get_destination_records", return_value=([], 1324))
-        records = [{"id": idx, "foo": "bar %s" % idx} for idx in range(0, 2)]
+        records = [
+            {"id": idx, "foo": "bar %s" % idx, "last_modified": 42 - idx} for idx in range(0, 2)
+        ]
         records.extend([{"id": idx, "deleted": True, "last_modified": 42} for idx in range(3, 5)])
         self.patch(self.updater, "get_source_records", return_value=(records, 1325))
         self.updater.push_records_to_destination(DummyRequest())
@@ -119,7 +125,9 @@ class LocalUpdaterTest(unittest.TestCase):
         # a RecordNotFoundError is raised.
         self.storage.delete.side_effect = RecordNotFoundError()
         self.patch(self.updater, "get_destination_records", return_value=([], 1324))
-        records = [{"id": idx, "foo": "bar %s" % idx} for idx in range(0, 2)]
+        records = [
+            {"id": idx, "foo": "bar %s" % idx, "last_modified": 42 - idx} for idx in range(0, 2)
+        ]
         records.extend([{"id": idx, "deleted": True, "last_modified": 42} for idx in range(3, 5)])
         self.patch(self.updater, "get_source_records", return_value=(records, 1325))
         # Calling the updater should not raise the RecordNotFoundError.
@@ -127,7 +135,9 @@ class LocalUpdaterTest(unittest.TestCase):
 
     def test_push_records_to_destination_with_no_destination_changes(self):
         self.patch(self.updater, "get_destination_records", return_value=([], None))
-        records = [{"id": idx, "foo": "bar %s" % idx} for idx in range(1, 4)]
+        records = [
+            {"id": idx, "foo": "bar %s" % idx, "last_modified": 42 - idx} for idx in range(1, 4)
+        ]
         self.patch(self.updater, "get_source_records", return_value=(records, 1325))
         self.updater.push_records_to_destination(DummyRequest())
         self.updater.get_source_records.assert_called_with(last_modified=None)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -95,6 +95,12 @@ class LocalUpdaterTest(unittest.TestCase):
         self.patch(self.updater, "get_source_records", return_value=(records, 1325))
         self.updater.push_records_to_destination(DummyRequest())
         assert self.storage.update.call_count == 3
+        assert self.storage.update.call_args_list[0][1] == {
+            "obj": {"id": 1, "foo": "bar 1"},
+            "object_id": 1,
+            "parent_id": "/buckets/destbucket/collections/destcollection",
+            "resource_name": "record",
+        }
 
     def test_push_records_to_destination_raises_if_storage_is_misconfigured(self):
         self.patch(self.updater, "get_destination_records", return_value=([{}], 1324))


### PR DESCRIPTION
Fixes #779

- [ ] Align on strategy (fix here or kinto-changes?)
- [x] Add tests
- [ ] Add changelog