### PR TITLE
Do not recreate tombstones on rollback (fixes #832)

### DIFF
--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -235,9 +235,7 @@ class LocalUpdater(object):
         cid = resource["collection"]
         parent_id = f"/buckets/{bid}/collections/{cid}"
 
-        records = self.storage.list_all(
-            parent_id=parent_id, resource_name="record", include_deleted=True
-        )
+        records = self.storage.list_all(parent_id=parent_id, resource_name="record")
 
         if len(records) == 0 and empty_none:
             # When the collection empty (no records and no tombstones)

--- a/tests/test_signoff_flow.py
+++ b/tests/test_signoff_flow.py
@@ -580,9 +580,10 @@ class RollbackChangesTest(SignoffWebTest, unittest.TestCase):
             self.source_collection, {"data": {"status": "to-rollback"}}, headers=self.headers
         )
 
-        self.app.get(
+        resp = self.app.get(
             self.source_collection + f"/records/{deleted_id}", headers=self.headers, status=200
         )
+        assert resp.json["data"]["title"] == "hello"
 
     def test_reverts_updated_records(self):
         resp = self.app.get(

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -50,9 +50,7 @@ class LocalUpdaterTest(unittest.TestCase):
 
         self.updater.get_source_records()
         self.storage.list_all.assert_called_with(
-            resource_name="record",
-            parent_id="/buckets/sourcebucket/collections/sourcecollection",
-            include_deleted=True,
+            resource_name="record", parent_id="/buckets/sourcebucket/collections/sourcecollection",
         )
 
     def test_get_destination_records(self):
@@ -66,9 +64,7 @@ class LocalUpdaterTest(unittest.TestCase):
             resource_name="record", parent_id="/buckets/destbucket/collections/destcollection"
         )
         self.storage.list_all.assert_called_with(
-            resource_name="record",
-            parent_id="/buckets/destbucket/collections/destcollection",
-            include_deleted=True,
+            resource_name="record", parent_id="/buckets/destbucket/collections/destcollection",
         )
 
     def test_push_records_to_destination(self):


### PR DESCRIPTION
Fixes #832

When listing the source and destination records sets, we would include tombstones. This is not necessary anymore since we do a plain comparison of the two sets (since #817).

There is still a failing test about reported startsd value, that I will look into as soon as I can