### PR TITLE
Send resource events on rollback 

### DIFF
--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -208,7 +208,7 @@ class LocalUpdater(object):
                     FIELD_ID: record[FIELD_ID],
                 }
                 record_uri = (
-                    "/buckets/{bucket_id}/collections" "/{collection_id}/records/{id}"
+                    "/buckets/{bucket_id}/collections/{collection_id}/records/{id}"
                 ).format(**matchdict)
 
                 notify_resource_event(

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -176,14 +176,14 @@ class LocalUpdater(object):
             if dest_record is None:
                 # In source, but not in destination. Must be deleted.
                 if not record.get("deleted"):
-                    self.storage.delete(
+                    tombstone = self.storage.delete(
                         object_id=record[FIELD_ID],
                         last_modified=record[FIELD_LAST_MODIFIED],
                         **storage_kwargs,
                     )
                     action = ACTIONS.DELETE
                     record_before = record
-                    impacted = record
+                    impacted = tombstone
 
             # In dest_records, but not in source_records. Must be re-created.
             elif record.get("deleted"):

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -168,6 +168,10 @@ class LocalUpdater(object):
 
         changed_count = 0
         for record in changes_since_approval:
+            action = None
+            record_before = None
+            impacted = None
+
             dest_record = dest_by_id.get(record[FIELD_ID])
             if dest_record is None:
                 # In source, but not in destination. Must be deleted.
@@ -177,17 +181,49 @@ class LocalUpdater(object):
                         last_modified=record[FIELD_LAST_MODIFIED],
                         **storage_kwargs,
                     )
-                    changed_count += 1
+                    action = ACTIONS.DELETE
+                    record_before = record
+                    impacted = record
 
             # In dest_records, but not in source_records. Must be re-created.
             elif record.get("deleted"):
                 self.storage.create(obj=dest_record, **storage_kwargs)
-                changed_count += 1
+                action = ACTIONS.CREATE
+                record_before = None
+                impacted = dest_record
 
             # Differ, restore attributes of dest_record in source.
             else:
                 self.storage.update(object_id=record[FIELD_ID], obj=dest_record, **storage_kwargs)
+                action = ACTIONS.UPDATE
+                record_before = record
+                impacted = dest_record
+
+            if action is not None:
                 changed_count += 1
+                # Notify resource event, in order to leave a trace in the history.
+                matchdict = {
+                    "bucket_id": self.destination["bucket"],
+                    "collection_id": self.destination["collection"],
+                    FIELD_ID: record[FIELD_ID],
+                }
+                record_uri = (
+                    "/buckets/{bucket_id}/collections" "/{collection_id}/records/{id}"
+                ).format(**matchdict)
+
+                notify_resource_event(
+                    request,
+                    {
+                        "method": "DELETE" if action == ACTIONS.DELETE else "PUT",
+                        "path": record_uri,
+                    },
+                    matchdict=matchdict,
+                    resource_name="record",
+                    parent_id=self.source_collection_uri,
+                    obj=impacted,
+                    action=action,
+                    old=record_before,
+                )
 
         if refresh_last_edit:
             current_userid = request.prefixed_userid

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -273,8 +273,7 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(events[2].payload["action"], "delete")
         self.assertEqual(len(events[2].impacted_objects), 1)
         self.assertEqual(events[2].impacted_objects[0]["old"]["title"], "some extra record")
-        # XXX
-        # self.assertEqual(events[2].impacted_objects[0].get("new"), None)
+        self.assertEqual(events[2].impacted_objects[0]["new"]["deleted"], True)
 
 
 class SignoffEventsTest(BaseWebTest, unittest.TestCase):


### PR DESCRIPTION
If rollback does not send events, then users are confused with information shown in the Admin UI. 
This should at least help have consistent info in history.


--> https://github.com/Kinto/kinto-admin/issues/1174#issuecomment-577728891