### PR TITLE
Records shouldn't contain float values anymore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 6.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Breaking changes**
+
+- Records cannot contain float values anymore. See ``signer.allow_floats`` settings to toggle old behaviour.
 
 
 6.1.0 (2020-03-27)

--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,11 @@ Here is an example of what a configuration could look like:
 |                                 | ``kinto.signer.signer.local_ecdsa`` or ``kinto.signer.signer.autograph`` |
 |                                 | Have a look at the sections below for more information.                  |
 +---------------------------------+--------------------------------------------------------------------------+
+| kinto.signer.allow_floats       | Allow float values in records (default: ``False``).                      |
+|                                 | Toggling this setting to ``True`` can lead to signature verification     |
+|                                 | errors in clients.                                                       |
+|                                 | See :ref:`kinto_signer.listeners.prevent_float_value`                    |
++---------------------------------+--------------------------------------------------------------------------+
 
 Configuration for the (default) ECDSA local signer
 --------------------------------------------------

--- a/kinto_signer/__init__.py
+++ b/kinto_signer/__init__.py
@@ -227,6 +227,14 @@ def includeme(config):
         for_resources=("collection",),
     )
 
+    if not asbool(settings.get("signer.allow_floats", False)):
+        config.add_subscriber(
+            functools.partial(listeners.prevent_float_value, resources=resources),
+            ResourceChanged,
+            for_actions=(ACTIONS.CREATE, ACTIONS.UPDATE),
+            for_resources=("record",),
+        )
+
     sign_data_listener = functools.partial(
         listeners.sign_collection_data, resources=resources, **global_settings
     )

--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -345,6 +345,47 @@ def signer_impacts_resource(signer, bid, cid):
     return False
 
 
+def prevent_float_value(event, resources):
+    """This ResourceChanged event listener will reject records that
+    contain float values.
+
+    In order to be able to align our Canonical JSON implementation with
+    the most elaborated specification [0], we must forbid floats to be
+    introduced in the system.
+
+    This is indeed the only area where our implementation differs, and
+    instead of supporting complex migration paths, getting rid of floats
+    is the simplest approach. Floats can be published as strings if needed.
+
+    [0] https://github.com/gibson042/canonicaljson-spec
+    """
+
+    def scan(d, path=""):
+        for k, v in d.items():
+            path = f"{path}.{k}" if path else k
+            if isinstance(v, float):
+                raise ValueError(f"'{path}' field contains float value " "(tip: use string)")
+            elif isinstance(v, dict):
+                scan(v, path)
+
+    # Only raise in configured resources.
+    resource, _ = pick_resource_and_signer(
+        event.request,
+        resources,
+        bucket_id=event.payload["bucket_id"],
+        collection_id=event.payload["collection_id"],
+    )
+    if resource is None:
+        return
+
+    # Check each created/updated record in the batch.
+    for impacted in event.impacted_objects:
+        try:
+            scan(impacted["new"])
+        except ValueError as e:
+            raise_invalid(message=str(e))
+
+
 def prevent_collection_delete(event, resources):
     request = event.request
     bid = event.payload["bucket_id"]

--- a/kinto_signer/listeners.py
+++ b/kinto_signer/listeners.py
@@ -364,7 +364,9 @@ def prevent_float_value(event, resources):
         for k, v in d.items():
             path = f"{path}.{k}" if path else k
             if isinstance(v, float):
-                raise ValueError(f"'{path}' field contains float value " "(tip: use string)")
+                raise ValueError(
+                    f"'{path}' field contains float value (tip: use integer or string)"
+                )
             elif isinstance(v, dict):
                 scan(v, path)
 


### PR DESCRIPTION
Using a script I could verify that only 3 records among all collections in the Remote Settings server use floats.
```
main/cfr 'content.text.addon.id.icon.title.users.author.rating' field contains float value 4.5 (tip: use string)
main/cfr 'content.text.addon.id.icon.title.users.author.rating' field contains float value 4.2 (tip: use string)
main/cfr 'content.text.addon.id.icon.title.users.author.rating' field contains float value 4.7 (tip: use string)
main-preview/cfr 'content.text.addon.id.icon.title.users.author.rating' field contains float value 4.5 (tip: use string)
main-preview/cfr 'content.text.addon.id.icon.title.users.author.rating' field contains float value 4.2 (tip: use string)
main-preview/cfr 'content.text.addon.id.icon.title.users.author.rating' field contains float value 4.7 (tip: use string)
```

After talking with the cfr team, this value is used to compute a CSS rule that shows a percentage of 5 stars (eg. `percent = rating * 100 / 5`). Since JavaScript has implicit casting, the field could be changed to string without consequences (`"4.1" * 100 / 5 == 81.9999`).
Once the data is changed and published on the server, we could start forbidding floats :tada: 