### PR TITLE
Remove ability to refresh signature with to-sign status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 8.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Breaking changes**
+
+- Removed ability to resign using ``to-sign`` twice. Use to ``to-resign`` instead.
 
 
 8.0.1 (2021-02-23)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -418,7 +418,7 @@ class SignoffEventsTest(BaseWebTest, unittest.TestCase):
         )
         del self.events[:]
         self.app.patch_json(
-            self.source_collection, {"data": {"status": "to-sign"}}, headers=self.headers
+            self.source_collection, {"data": {"status": "to-resign"}}, headers=self.headers
         )
         assert len(self.events) == 0
 

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -331,7 +331,9 @@ class BatchTest(BaseWebTest, unittest.TestCase):
 
     def test_various_collections_can_be_signed_using_batch(self):
         self.app.put_json("/buckets/alice/collections/source", headers=self.headers)
+        self.app.post_json("/buckets/alice/collections/source/records", headers=self.headers)
         self.app.put_json("/buckets/bob/collections/source", headers=self.headers)
+        self.app.post_json("/buckets/bob/collections/source/records", headers=self.headers)
 
         self.app.post_json(
             "/batch",


### PR DESCRIPTION
This removes the old way to refresh signatures, and improves the overall API consistency.