### PR TITLE
Reset the editor/reviewer comments when not specified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ This document describes changes between each past release.
 
 - Removed ability to resign using ``to-sign`` twice. Use to ``to-resign`` instead.
 
+**Bug fixes**
+
+- Reset the editor/reviewer comments when not specified.
+
 
 8.0.1 (2021-02-23)
 ------------------

--- a/kinto_signer/updater.py
+++ b/kinto_signer/updater.py
@@ -223,7 +223,11 @@ class LocalUpdater(object):
         if refresh_last_edit:
             current_userid = request.prefixed_userid
             current_date = datetime.datetime.now(datetime.timezone.utc).isoformat()
-            attrs = {"status": STATUS.SIGNED.value}
+            attrs = {
+                "status": STATUS.SIGNED.value,
+                "last_editor_comment": "",
+                "last_reviewer_comment": "",
+            }
             attrs[TRACKING_FIELDS.LAST_EDIT_BY.value] = current_userid
             attrs[TRACKING_FIELDS.LAST_EDIT_DATE.value] = current_date
             self._update_source_attributes(request, **attrs)
@@ -409,6 +413,9 @@ class LocalUpdater(object):
         if status == STATUS.TO_REVIEW:
             attrs[TRACKING_FIELDS.LAST_REVIEW_REQUEST_BY.value] = current_userid
             attrs[TRACKING_FIELDS.LAST_REVIEW_REQUEST_DATE.value] = current_date
+            # Make sure we reset the review comments if none is specified.
+            if "last_editor_comment" not in request.validated["body"].get("data", {}):
+                attrs["last_editor_comment"] = ""
         if status == STATUS.SIGNED:
             if old_status != STATUS.SIGNED:
                 # Do not keep track of reviewer when refreshing signature.

--- a/tests/test_signoff_flow.py
+++ b/tests/test_signoff_flow.py
@@ -585,6 +585,26 @@ class RollbackChangesTest(SignoffWebTest, unittest.TestCase):
         after_date = resp.json["data"]["last_edit_date"]
         assert before_date != after_date
 
+    def test_comments_are_reset(self):
+        self.app.patch_json(
+            self.source_collection,
+            {
+                "data": {
+                    "last_editor_comment": "please check that",
+                    "last_reviewer_comment": "looks good",
+                }
+            },
+            headers=self.headers,
+        )
+
+        self.app.patch_json(
+            self.source_collection, {"data": {"status": "to-rollback"}}, headers=self.headers
+        )
+
+        resp = self.app.get(self.source_collection, headers=self.headers)
+        assert resp.json["data"]["last_editor_comment"] == ""
+        assert resp.json["data"]["last_reviewer_comment"] == ""
+
     def test_recreates_deleted_record(self):
         resp = self.app.delete(
             self.source_collection + "/records?_limit=1&_sort=last_modified", headers=self.headers
@@ -954,6 +974,25 @@ class PreviewCollectionTest(SignoffWebTest, unittest.TestCase):
         resp = self.app.get(self.preview_collection + "/records", headers=self.headers)
         records = resp.json["data"]
         assert len(records) == 0
+
+    def test_last_editor_comment_are_reset_on_review(self):
+        self.app.patch_json(
+            self.source_collection,
+            {
+                "data": {
+                    "last_editor_comment": "please check that",
+                    "last_reviewer_comment": "looks good",
+                }
+            },
+            headers=self.headers,
+        )
+
+        self.app.patch_json(
+            self.source_collection, {"data": {"status": "to-review"}}, headers=self.headers
+        )
+
+        resp = self.app.get(self.source_collection, headers=self.headers)
+        assert resp.json["data"]["last_editor_comment"] == ""
 
 
 class CollectionDelete(SignoffWebTest, unittest.TestCase):


### PR DESCRIPTION
See https://github.com/Kinto/kinto-admin/issues/1918